### PR TITLE
Render to PDF and fix some issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,14 @@
 /.quarto/
 .Rproj.user
 .Rhistory
+.DS_Store
+*.orig
 
 # ignore the rendered book, since GHA does that for us
 _book
 _freeze
 site_libs
-*_files 
+*_files
 
 .venv
 
@@ -14,7 +16,7 @@ site_libs
 data
 PUMS_smol
 
-# quarto + tex detritus
+# ignore pdf rendering artifacts
 index.aux
 index.bbl
 index.blg
@@ -22,4 +24,7 @@ index.log
 index.pdf
 index.tex
 /krantz.cls
-Scaling-Up-With-R-and-Arrow.tex
+/Scaling-Up-With-R-and-Arrow.tex
+# IDK why these get generated here
+/advanced_topics_files
+/getting_started_files

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -8,7 +8,7 @@ book:
   author: "Nic Crane, Jonathan Keane, and Neal Richardson"
   reader-mode: true
   google-analytics: "G-4JT42QR6DV"
-  
+
 
   page-footer:
     left: |

--- a/advanced_topics.qmd
+++ b/advanced_topics.qmd
@@ -156,7 +156,9 @@ For example, arrow has historically had better dplyr support than duckdb because
 On the other hand, Acero does not currently have a SQL interface.
 But there is no technical limitations preventing duckdb from improving dplyr support---and by the time you are reading this, they very well may have![^duckplyr]---nor from there being a SQL interface to arrow.
 
-[^duckplyr: Indeed, see [duckplyr](https://duckdblabs.github.io/duckplyr/).]
+[^duckplyr]: Indeed, see
+[[duckplyr](https://duckdblabs.github.io/duckplyr/).]{.content-visible when-format="html"}
+[duckplyr: https://duckdblabs.github.io/duckplyr/.]{.content-visible when-format="pdf"}
 
 For most applications, you could use either arrow or duckdb just fine.
 But, if you do encounter cases where one package supports something the other doesn't, the smooth integration between arrow and duckdb means can leverage the best of both.
@@ -219,7 +221,7 @@ library(ggplot2)
 library(dplyr)
 library(patchwork) # For combining multiple ggplot objects
 
-# Define a function to create a plot with a given 
+# Define a function to create a plot with a given
 # CRS and parallel gridlines
 create_plot <- function(us_sf, crs, title) {
   us_transformed <- st_transform(us_sf, crs)
@@ -380,7 +382,7 @@ Finally, we pull the data into R and set the correct geometry column to use.
 #| label: correct-projection
 correct_projection <- function(PUMA, crs = "NAD83") {
   PUMA_df <- collect(PUMA)
-  # set the geometry column, but we also need to manually 
+  # set the geometry column, but we also need to manually
   # extract the CRS from the geoparquet metadata
   PUMA_df <- sf::st_sf(PUMA_df, sf_column_name = "geometry",
                        crs = crs)
@@ -391,11 +393,11 @@ correct_projection <- function(PUMA, crs = "NAD83") {
     "+proj=aea",
     "+lat_1=29.5",
     "+lat_2=45.5",
-    "+lat_0=23", 
+    "+lat_0=23",
     "+lon_0=-96",
     "+x_0=0",
     "+y_0=0",
-    "+ellps=GRS80", 
+    "+ellps=GRS80",
     "+towgs84=0,0,0,0,0,0,0",
     "+units=m +no_defs"
   )
@@ -511,8 +513,8 @@ puma_by_langauge |>
           lwd = 0) +
   coord_sf(crs = "+proj=laea +lon_0=-98 +lat_0=39.5") +
   facet_wrap(vars(language), ncol = 2) +
-  scale_fill_distiller(type = "seq", direction = 1, 
-                       palette = "Greys", 
+  scale_fill_distiller(type = "seq", direction = 1,
+                       palette = "Greys",
                        name = "proportion of speakers") +
   theme_minimal() +
   theme(legend.position = "bottom") +
@@ -596,7 +598,7 @@ This shifts the projection slightly to be as if it were on a globe.
 Making small multiples for each language
 
 ```{.r}
-  scale_fill_distiller(type = "seq", direction = 1, 
+  scale_fill_distiller(type = "seq", direction = 1,
     palette = "Greys", name = "proportion of speakers") +
   theme_minimal() +
   theme(legend.position = "bottom") +
@@ -622,8 +624,8 @@ We've selected slightly different languages for each area to highlight unique di
 puma_by_langauge |>
   filter(language %in% c("english", "spanish", "polish")) |>
   fill_pumas() |>
-  inner_join(PUMA, by = c("year" = "YEAR", 
-                          "location" = "location", 
+  inner_join(PUMA, by = c("year" = "YEAR",
+                          "location" = "location",
                           "PUMA" = "PUMA")) |>
   correct_projection() |>
   ggplot() +
@@ -636,8 +638,8 @@ puma_by_langauge |>
     expand = FALSE
   ) +
   facet_wrap(vars(language), ncol = 3) +
-  scale_fill_distiller(type = "seq", direction = 1, 
-                       palette = "Greys", 
+  scale_fill_distiller(type = "seq", direction = 1,
+                       palette = "Greys",
                        name = "proportion of speakers") +
   theme_minimal() +
   theme(legend.position = "bottom") +
@@ -703,15 +705,15 @@ Or the Northeast, where there are a relatively large proportion of Portugese spe
 #| label: pums-langauge-northeast
 #| eval: false
 puma_by_langauge |>
-  filter(language %in% c("english", "spanish", "french", 
+  filter(language %in% c("english", "spanish", "french",
                          "portuguese")) |>
   fill_pumas() |>
-  inner_join(PUMA, by = c("year" = "YEAR", 
-                          "location" = "location", 
+  inner_join(PUMA, by = c("year" = "YEAR",
+                          "location" = "location",
                           "PUMA" = "PUMA")) |>
   correct_projection() |>
   ggplot() +
-  geom_sf(aes(geometry = geometry, fill = prop_speaker), 
+  geom_sf(aes(geometry = geometry, fill = prop_speaker),
           lwd = 0) +
   coord_sf(
     xlim = c(000000, 650000),
@@ -720,8 +722,8 @@ puma_by_langauge |>
     expand = FALSE
   ) +
   facet_wrap(vars(language), ncol = 4) +
-  scale_fill_distiller(type = "seq", direction = 1, 
-                       palette = "Greys", name = 
+  scale_fill_distiller(type = "seq", direction = 1,
+                       palette = "Greys", name =
                          "proportion of speakers") +
   theme_minimal() +
   theme(legend.position = "bottom") +
@@ -786,4 +788,6 @@ Finally, we took a look at extending arrow, with a focus on geospatial data, int
 
 [^alaska]: Without this, some of the Aleutian islands which are to the west of the 180th meridian will be plotted to the east of the rest of the United States.
 
-[^pumas-rawr]: There is also a more [detailed description of PUMAs](https://walker-data.com/census-r/introduction-to-census-microdata.html#what-is-a-puma) in Kyle Walker's _Analyzing US Census Data: Methods, Maps, and Models in R_
+[^pumas-rawr]: There is also a more
+[[detailed description of PUMAs](https://walker-data.com/census-r/introduction-to-census-microdata.html#what-is-a-puma) in Kyle Walker's _Analyzing US Census Data: Methods, Maps, and Models in R_]{.content-visible when-format="html"}
+[detailed description of PUMAs in Kyle Walker's _Analyzing US Census Data: Methods, Maps, and Models in R_: https://walker-data.com/census-r/introduction-to-census-microdata.html#what-is-a-puma]{.content-visible when-format="pdf"}

--- a/advanced_topics.qmd
+++ b/advanced_topics.qmd
@@ -373,7 +373,7 @@ When this book was being written, there were already nascent projects to make th
 Today, however, we need to do a couple more things before we can work with it further and use `sf` and `ggplot2` to plot this: make sure that our CRS is set correctly and pulling the data into R.
 To do both of these, we create a helper function.
 This helper function ensures that we use the CRS we saw the data had above.
-It also sets the bounding box and center so that the entirety of the United States is laid out correctly.[^2]
+It also sets the bounding box and center so that the entirety of the United States is laid out correctly.[^alaska]
 Finally, we pull the data into R and set the correct geometry column to use.
 
 ```{r}
@@ -407,10 +407,10 @@ correct_projection <- function(PUMA, crs = "NAD83") {
 
 ### Enhancing PUMS data with GeoParquet PUMAs data {#sec-pums-pumas}
 
-Putting this all together, let's try making a plot[^1] showing different languages spoken throughout the United States.
+Putting this all together, let's try making a plot[^lang-choropleth] showing different languages spoken throughout the United States.
 The analysis we will build up is the percentage of speakers for languages spoken in the US.
 We will then plot this data, subsetting to a few interesting languages depending on what region we are plotting.
-In the PUMS dataset, the smallest geographic area is called a [PUMA (Public Use Microdata Areas)](https://www.census.gov/programs-surveys/geography/guidance/geo-areas/pumas.html).[^3]
+In the PUMS dataset, the smallest geographic area is called a [PUMA (Public Use Microdata Areas)](https://www.census.gov/programs-surveys/geography/guidance/geo-areas/pumas.html).[^pumas-rawr]
 These PUMAs are designed to have approximately 100,000 people in them, and must be within a single state.
 
 As always, we start with our PUMS dataset.
@@ -782,8 +782,8 @@ We began talking about user-defined functions (UDFs), explaining how to create a
 We also looked at the interoperability between Arrow and DuckDB, showing how to use DuckDB for tasks not natively supported in Arrow.
 Finally, we took a look at extending arrow, with a focus on geospatial data, introducing the concept of GeoParquet for on-disk geospatial data representation that can quickly and easily be turned into an in-memory representation.
 
-[^1]: This type of plot is called a choropleth where a geographic representation is colored or shaded to show different values in different areas.
+[^lang-choropleth]: This type of plot is called a choropleth where a geographic representation is colored or shaded to show different values in different areas.
 
-[^2]: Without this, some of the Aleutian islands which are to the west of the 180th meridian will be plotted to the east of the rest of the United States.
+[^alaska]: Without this, some of the Aleutian islands which are to the west of the 180th meridian will be plotted to the east of the rest of the United States.
 
-[^3]: There is also a more [detailed description of PUMAs](https://walker-data.com/census-r/introduction-to-census-microdata.html#what-is-a-puma) in Kyle Walker's _Analyzing US Census Data: Methods, Maps, and Models in R_
+[^pumas-rawr]: There is also a more [detailed description of PUMAs](https://walker-data.com/census-r/introduction-to-census-microdata.html#what-is-a-puma) in Kyle Walker's _Analyzing US Census Data: Methods, Maps, and Models in R_

--- a/cloud.qmd
+++ b/cloud.qmd
@@ -13,7 +13,10 @@ If you want to read a single file directly into memory, you can pass a URL direc
 
 ```{r}
 #| label: read_parquet_url
-read_parquet(system.file("v0.7.1.parquet", package = "arrow"))
+
+read_parquet(
+  "https://github.com/apache/arrow/raw/main/r/inst/v0.7.1.parquet"
+)
 ```
 
 If you want to work with multi-file datasets, however, the HTTP protocol isn't compatible with Arrow's ability to scan files and read metadata before data is accessed to optimize what is eventually pulled into memory upon collecting a query.
@@ -65,7 +68,7 @@ To open a file or dataset saved in cloud storage, instead of passing in a path t
 #| label: open_parquet_s3
 #| eval: false
 read_parquet(
-  paste0("s3://scaling-arrow-pums/person/year=2005/", 
+  paste0("s3://scaling-arrow-pums/person/year=2005/",
          "location=ak/part-0.parquet")
 )
 open_dataset("s3://scaling-arrow-pums/person/")
@@ -78,7 +81,7 @@ The equivalent of the above commands for GCS---these won't run here as these buc
 #| label: open_parquet_gcs
 #| eval: false
 read_parquet(
-  paste0("gs://anonymous@scaling-arrow-pums/person/year=2005/", 
+  paste0("gs://anonymous@scaling-arrow-pums/person/year=2005/",
          "location=ak/part-0.parquet"
         )
 )

--- a/cloud.qmd
+++ b/cloud.qmd
@@ -50,9 +50,9 @@ While you can work with compressed CVSs, this solves part of the problem, but no
 
 Many examples will look at working with data hosted on Amazon S3, but the same principles can also be used with data in GCS.
 There are some subtle differences between S3 and GCS which we'll highlight when they come up and outline any differences you need to be aware of.
-In the future, the Apache Arrow project plans to add functionality to work with additional cloud storage services like Azure Blob Storage---this implementation and future ones relating to any other cloud storage services will also follow this model.[^1]
+In the future, the Apache Arrow project plans to add functionality to work with additional cloud storage services like Azure Blob Storage---this implementation and future ones relating to any other cloud storage services will also follow this model.[^azure]
 
-[^1]: At the time of writing, the Arrow C++ library has introduced support for Azure Blob Storage. Users of PyArrow can query datasets on Azure from Python, and once bindings are added to the arrow R package, it will be available from R.
+[^azure]: At the time of writing, the Arrow C++ library has introduced support for Azure Blob Storage. Users of PyArrow can query datasets on Azure from Python, and once bindings are added to the arrow R package, it will be available from R.
 
 In cloud storage terminology, S3 and GCS refer to the place where the data is stored as a **bucket**.  Other systems may use alternative terms, like "blob", but we will use "bucket" here as a generic term.
 

--- a/data_manipulation.qmd
+++ b/data_manipulation.qmd
@@ -39,10 +39,10 @@ We can point at all of the files and query them together as a single dataset mad
 #| label: now_use_parquet
 pums_person <- open_dataset("./data/person")
 ```
-Although a lot of the cleaning has been done — we've recoded all of the character and factor variables, replaced sentinels[^2] for missing values with actual missing values, etc. — there are still some data transformations that we will demonstrate using Arrow for throughout the rest of this chapter and book.
+Although a lot of the cleaning has been done — we've recoded all of the character and factor variables, replaced sentinels[^sentinel] for missing values with actual missing values, etc. — there are still some data transformations that we will demonstrate using Arrow for throughout the rest of this chapter and book.
 
 You can create data analysis pipelines in arrow similarly to how you would using dplyr.
-For example, if you wanted to calculate the mean age of individuals from Washington across the years, you could run:[^1]
+For example, if you wanted to calculate the mean age of individuals from Washington across the years, you could run:[^well-actually-weights]
 
 ```{r}
 #| label: building-queries
@@ -211,7 +211,7 @@ You can use these functions with or without namespacing, so either `stringr::str
 
 When we wrote this book, there were 37 dplyr functions and 211 other functions available in arrow---though this number may have increased since!
 We've demonstrated some string operations here; both the base R and stringr flavors are supported.
-There is also deep support for **lubridate** functions for working with date and time data.[^3]
+There is also deep support for **lubridate** functions for working with date and time data.[^user-2022]
 If you want to find out which functions are available in arrow, you can view the help page which lists all of the dplyr functions and other function mappings by calling `?acero`.
 
 While many functions are implemented in arrow, you aren't limited by just what is included in the package.
@@ -410,8 +410,8 @@ This allowed us to run analyses on datasets that in total are larger than can fi
 The next chapter will go into more details about how and why datasets work in Arrow for a deeper understanding of the capabilities, caveats, and best practices.
 
 
-[^1]: Note, that we might think we could use `summarize(mean_age = mean(AGEP))`, but because this dataset has row-level weights, we need to account for that in our analysis to get accurate results.
+[^well-actually-weights]: Note, that we might think we could use `summarize(mean_age = mean(AGEP))`, but because this dataset has row-level weights, we need to account for that in our analysis to get accurate results.
 
-[^2]: Sentinel may be an unfamiliar term — you could think of it as a placeholder value. It is used in the survey research and database worlds to refer to special values that have a special meaning. For example, you might have an age variable that can take any (positive) integer. But when the age is listed as `-1` that means that the data is missing — not that someone is negative years old! This, again, is another example where old customs when CSVs and other text-based formats were the only ways to transport data forced us to do some funky things to communicate some values.
+[^sentinel]: Sentinel may be an unfamiliar term — you could think of it as a placeholder value. It is used in the survey research and database worlds to refer to special values that have a special meaning. For example, you might have an age variable that can take any (positive) integer. But when the age is listed as `-1` that means that the data is missing — not that someone is negative years old! This, again, is another example where old customs when CSVs and other text-based formats were the only ways to transport data forced us to do some funky things to communicate some values.
 
-[^3]: The 2022 UseR! conference workshop on arrow, "[Larger-Than-Memory Data Workflows with Apache Arrow](https://arrow-user2022.netlify.app/)," by Danielle Navarro, Jonathan Keane, and Stephanie Hazlitt, has some good examples that show more functions being used, including [datetime functions](https://arrow-user2022.netlify.app/data-wrangling#example-4-datetime-support). We figured everyone had seen enough of the NYC taxi dataset and chose to use U.S. Census data for examples in this book. This means we can show some more interesting queries and results, but unfortunately, there is no interesting datetime data in it!
+[^user-2022]: The 2022 UseR! conference workshop on arrow, "[Larger-Than-Memory Data Workflows with Apache Arrow](https://arrow-user2022.netlify.app/)," by Danielle Navarro, Jonathan Keane, and Stephanie Hazlitt, has some good examples that show more functions being used, including [datetime functions](https://arrow-user2022.netlify.app/data-wrangling#example-4-datetime-support). We figured everyone had seen enough of the NYC taxi dataset and chose to use U.S. Census data for examples in this book. This means we can show some more interesting queries and results, but unfortunately, there is no interesting datetime data in it!

--- a/data_manipulation.qmd
+++ b/data_manipulation.qmd
@@ -108,17 +108,17 @@ We can use the dplyr function `case_when()` to replace the older values with the
 pums_person |>
   mutate(
     CIT = case_when(
-      CIT == "Yes, born in the US" ~ 
+      CIT == "Yes, born in the US" ~
         "Born in the United States",
-      CIT == "Yes, naturalized" ~ 
+      CIT == "Yes, naturalized" ~
         "U.S. citizen by naturalization",
-      CIT == "Not a citizen" ~ 
+      CIT == "Not a citizen" ~
         "Not a U.S. citizen",
-      CIT == "Yes, born abroad of American parent(s)" ~ 
+      CIT == "Yes, born abroad of American parent(s)" ~
         "Born abroad of U.S. citizen parent or parents",
-      CIT == "Yes, born in Puerto Rico, etc." ~ 
+      CIT == "Yes, born in Puerto Rico, etc." ~
         paste0(
-          "Born in Puerto Rico, Guam, the U.S. Virgin Islands,", 
+          "Born in Puerto Rico, Guam, the U.S. Virgin Islands,",
           " or Northern Marianas"
         )
     )
@@ -282,7 +282,7 @@ We start by creating a reference table of mean commute time by state and year.
 mean_commute_time <- pums_person |>
   group_by(location, year) |>
   summarize(
-    mean_commute_time = sum(JWMNP * PWGTP, na.rm = TRUE) / 
+    mean_commute_time = sum(JWMNP * PWGTP, na.rm = TRUE) /
       sum(PWGTP)
   ) |>
   collect()
@@ -414,4 +414,7 @@ The next chapter will go into more details about how and why datasets work in Ar
 
 [^sentinel]: Sentinel may be an unfamiliar term — you could think of it as a placeholder value. It is used in the survey research and database worlds to refer to special values that have a special meaning. For example, you might have an age variable that can take any (positive) integer. But when the age is listed as `-1` that means that the data is missing — not that someone is negative years old! This, again, is another example where old customs when CSVs and other text-based formats were the only ways to transport data forced us to do some funky things to communicate some values.
 
-[^user-2022]: The 2022 UseR! conference workshop on arrow, "[Larger-Than-Memory Data Workflows with Apache Arrow](https://arrow-user2022.netlify.app/)," by Danielle Navarro, Jonathan Keane, and Stephanie Hazlitt, has some good examples that show more functions being used, including [datetime functions](https://arrow-user2022.netlify.app/data-wrangling#example-4-datetime-support). We figured everyone had seen enough of the NYC taxi dataset and chose to use U.S. Census data for examples in this book. This means we can show some more interesting queries and results, but unfortunately, there is no interesting datetime data in it!
+[^user-2022]: The 2022 UseR! conference workshop on arrow,
+["[Larger-Than-Memory Data Workflows with Apache Arrow](https://arrow-user2022.netlify.app/)," by Danielle Navarro, Jonathan Keane, and Stephanie Hazlitt, has some good examples that show more functions being used, including [datetime functions](https://arrow-user2022.netlify.app/data-wrangling#example-4-datetime-support).]{.content-visible when-format="html"}
+["Larger-Than-Memory Data Workflows with Apache Arrow," by Danielle Navarro, Jonathan Keane, and Stephanie Hazlitt, has some good examples that show more functions being used, including datetime functions. See https://arrow-user2022.netlify.app/.]{.content-visible when-format="pdf"}
+We figured everyone had seen enough of the NYC taxi dataset and chose to use U.S. Census data for examples in this book. This means we can show some more interesting queries and results, but unfortunately, there is no interesting datetime data in it!

--- a/files_and_formats.qmd
+++ b/files_and_formats.qmd
@@ -647,7 +647,7 @@ This preservation of custom attributes and classes is helpful because it means t
 One thing to note is that this preservation of custom attributes works automatically when you write a Parquet file from R and then read it in to R, but it won't work automatically when writing from R and then reading in another language like Python.
 The custom metadata for each language implementation is stored in a separate location for each language.
 So while reading data into Python which has a custom class that was created in R, Arrow won't automatically create that same class.
-However, you still do have access to that metadata under the `metadata` and then `r` attribute if there are details you need to access from Python. 
+However, you still do have access to that metadata under the `metadata` and then `r` attribute if there are details you need to access from Python.
 
 ### File structure and parallelisation
 
@@ -853,7 +853,7 @@ That is, we'll keep the data in Arrow memory and never pull it into an R data fr
 
 Let's look at the PUMS dataset.
 It is a survey, and it has some features commonly found in surveys that need to be cleaned up.
-For one, the actual row-level data in the survey is encoded based on the type of data it represents.[^1]
+For one, the actual row-level data in the survey is encoded based on the type of data it represents.[^punchcards]
 For columns that are numeric, the data is what is in the data file, but characters, factors, and missing values are recorded as integers.
 <!-- NPR: missing values actually look like empty cells in the CSV, not -1 or whatever -->
 These integers must be mapped to values in the codebook, which is distributed with the data and acts as a lookup for what actual value is represented by the integer in the dataset.
@@ -861,7 +861,7 @@ These integers must be mapped to values in the codebook, which is distributed wi
 For another, the survey questions have changed over time, so data from one year may not line up perfectly with data from other years without some adjustment.
 Many columns in this dataset require transformation to create a nice consistent dataset to work with.
 
-[^1]: Exploring the reasons for this convention is outside of the scope of this book, but it is partly because, historically, folks working with surveys used tools and frameworks that made working with large amounts of data that _wasn't_ numeric difficult.
+[^punchcards]: Exploring the reasons for this convention is outside of the scope of this book, but it is partly because, historically, folks working with surveys used tools and frameworks that made working with large amounts of data that _wasn't_ numeric difficult.
 However, with modern data tools like arrow, we can effectively and efficiently work with data of all types!
 
 Let's start with the `COW` variable, which represents class of worker, categorizing people based on their employment status.

--- a/files_and_formats.qmd
+++ b/files_and_formats.qmd
@@ -382,7 +382,7 @@ In real use, call `one_state_schema$code()` to use the whole schema.
 #| label: schema-code
 # Print the code needed to create this schema
 one_state_schema[
-  c("RT", "SERIALNO", "DIVISION", "SPORDER", 
+  c("RT", "SERIALNO", "DIVISION", "SPORDER",
     "PUMA", "REGION", "ST")
 ]$code()
 ```
@@ -395,7 +395,7 @@ You can add a new item by assigning a data type to a new item in the schema.
 #| label: add_to_schema
 one_state_schema[["new_var"]] <- float64()
 one_state_schema[
-  c("RT", "SERIALNO", "DIVISION", "SPORDER", 
+  c("RT", "SERIALNO", "DIVISION", "SPORDER",
     "PUMA", "REGION", "ST", "new_var")
 ]
 ```
@@ -404,7 +404,7 @@ To remove items from a schema or select a subset, you can create a new schema co
 
 ```{r}
 #| label: schema_subset
-to_keep <- c("RT", "SERIALNO", "DIVISION", "SPORDER", "PUMA", 
+to_keep <- c("RT", "SERIALNO", "DIVISION", "SPORDER", "PUMA",
              "REGION", "ST", "AGEP", "new_var")
 one_state_schema_mini <- one_state_schema[to_keep]
 one_state_schema_mini
@@ -595,7 +595,7 @@ fraction <- function(n = integer(), d = integer()) {
 
 }
 
-# define a format method for the object 
+# define a format method for the object
 # so we can control how it's printed
 format.fraction <- function(x, ...) {
   paste0(field(x, "numerator"), "/", field(x, "denominator"))
@@ -685,7 +685,7 @@ First, let's look at the file size of the Parquet file for Washington in 2021, w
 ```{r}
 #| label: pums-subset-size
 wa_21_path <- paste0(
-  "./data/person/year=2021/location=wa/", 
+  "./data/person/year=2021/location=wa/",
   "part-0.parquet"
 )
 fs::file_size(wa_21_path)
@@ -946,7 +946,7 @@ We can do this with multiple variables at once, and when we're happy with the re
 #| eval: false
 wa_2005 |>
   left_join(
-    filter(codebook, name == "COW"), 
+    filter(codebook, name == "COW"),
     by = c("COW" = "values_code")
   ) |>
   mutate(COW = values_label, .keep = "unused") |>

--- a/getting_started.qmd
+++ b/getting_started.qmd
@@ -44,9 +44,9 @@ If you want to know more details about the dataset, including how you can get ho
 Let's take a look at the data in R.
 The data is stored in a directory called `./data/pums/person`.
 This is further split into multiple directories, one for each year, and then within those directories, one for each location.
-Finally, within each state directory, there is a single Parquet file containing the data for that year and location.[^1]
+Finally, within each state directory, there is a single Parquet file containing the data for that year and location.[^parquet-is-coming]
 
-[^1]: Unfamiliar with the Parquet file format? Don't worry, we'll cover that in [Chapter @sec-filesformats]
+[^parquet-is-coming]: Unfamiliar with the Parquet file format? Don't worry, we'll cover that in [Chapter @sec-filesformats]
 
 ```
 ./data/pums/person/

--- a/index.qmd
+++ b/index.qmd
@@ -1,7 +1,9 @@
-# Welcome {.unnumbered}
+::: {.content-hidden when-format="pdf"}
 
 This is the website for Scaling Up with R and Arrow.
 
-## Acknowledgements {.unnumbered}
+:::
+
+# Acknowledgements {.unnumbered}
 
 A huge thanks to folks who gave us writing advice and really helpful feedback on our drafts of this book, including Sam Albers, Carl Boettiger, Raúl Cumplido, Dewey Dunnington, Alenka Frim, Colin Gillespie, Stephanie Hazlitt, Jared Lander, Bryce Mecum, François Michonneau, Danielle Navarro, Antoine Pitrou, Brian Repko, and Jacob Wujciak-Jens.

--- a/intro.qmd
+++ b/intro.qmd
@@ -166,8 +166,11 @@ For example, missing data is represented as a bitmask for all data types, unlike
 Filtering by missing values, or checking if values are missing, is faster using bitmasks.[^wes]
 The Arrow string array is also represented in a way that improves the efficiency and speed of access relative to R and Python.[^danielle]
 
-[^wes]: Wes McKinney describes the rationale well [here](https://wesmckinney.com/blog/apache-arrow-pandas-internals/).
-[^danielle]: [This blog post by Danielle Navarro](https://blog.djnavarro.net/posts/2022-03-04_data-types-in-arrow-and-r/#character-types) provides an accessible explanation of the Arrow string data type.
+[^wes]: Wes McKinney describes the rationale well
+[[here](https://wesmckinney.com/blog/apache-arrow-pandas-internals/).]{.content-visible when-format="html"}
+[here: https://wesmckinney.com/blog/apache-arrow-pandas-internals/.]{.content-visible when-format="pdf"}
+[^danielle]: [[This blog post by Danielle Navarro](https://blog.djnavarro.net/posts/2022-03-04_data-types-in-arrow-and-r/#character-types) provides an accessible explanation of the Arrow string data type.]{.content-visible when-format="html"}
+[This blog post by Danielle Navarro provides an accessible explanation of the Arrow string data type: https://blog.djnavarro.net/posts/2022-03-04_data-types-in-arrow-and-r/#character-types.]{.content-visible when-format="pdf"}
 
 Second, Arrow has a **rich type system**, encompassing all key data structures found across the database landscape, including many types not natively supported in R.[^type-appendix]
 Bringing together the type system with the columnar data layout, we get the Arrow specification.

--- a/intro.qmd
+++ b/intro.qmd
@@ -163,18 +163,18 @@ The result of this is that when the data manipulation task involved retrieving v
 The Arrow specification is a columnar format, and so is optimized for analytical workflows.
 Furthermore, implementation choices in the memory layout are optimized for fast evaluation and aggregation.
 For example, missing data is represented as a bitmask for all data types, unlike R, pandas, and NumPy, which use sentinel values that vary by type.
-Filtering by missing values, or checking if values are missing, is faster using bitmasks.[^1]
-The Arrow string array is also represented in a way that improves the efficiency and speed of access relative to R and Python.[^2]
+Filtering by missing values, or checking if values are missing, is faster using bitmasks.[^wes]
+The Arrow string array is also represented in a way that improves the efficiency and speed of access relative to R and Python.[^danielle]
 
-[^1]: Wes McKinney describes the rationale well [here](https://wesmckinney.com/blog/apache-arrow-pandas-internals/).
-[^2]: [This blog post by Danielle Navarro](https://blog.djnavarro.net/posts/2022-03-04_data-types-in-arrow-and-r/#character-types) provides an accessible explanation of the Arrow string data type.
+[^wes]: Wes McKinney describes the rationale well [here](https://wesmckinney.com/blog/apache-arrow-pandas-internals/).
+[^danielle]: [This blog post by Danielle Navarro](https://blog.djnavarro.net/posts/2022-03-04_data-types-in-arrow-and-r/#character-types) provides an accessible explanation of the Arrow string data type.
 
-Second, Arrow has a **rich type system**, encompassing all key data structures found across the database landscape, including many types not natively supported in R.[^3]
+Second, Arrow has a **rich type system**, encompassing all key data structures found across the database landscape, including many types not natively supported in R.[^type-appendix]
 Bringing together the type system with the columnar data layout, we get the Arrow specification.
 Reducing it to its core, Arrow defines **Arrays**, columns of data of the same type.
 A data-frame-like arrangement of Arrays of equal length is a **RecordBatch**, which has a **Schema** that maps column names to the corresponding data types.
 
-[^3]: See [Appendix @sec-arrow-types] for full list of types and how they map to R types.
+[^type-appendix]: See [Appendix @sec-arrow-types] for full list of types and how they map to R types.
 
 Libraries can then define additional abstractions on top of those core structures.
 For example, in C++ (and thus the R package) we have a **Table**, which can be thought of as a data frame that is chunked into multiple batches, and a **RecordBatchReader**, an iterator that yields RecordBatches for processing.

--- a/writers notes/README.md
+++ b/writers notes/README.md
@@ -4,17 +4,17 @@ Published site: [arrowrbook.com](https://arrowrbook.com)
 
 ## How to render
 
-All of the code in this book assumes that the data is at `data/` within the repo. 
-For convenience of writing, all examples can run with either the full data or the subset data. 
+All of the code in this book assumes that the data is at `data/` within the repo.
+For convenience of writing, all examples can run with either the full data or the subset data.
 Which is used depends on which is in (or linked to) the `data/` directory.
 Doing this allows us to have quick iteration cycles knowing that we can compile with examples and write examples without needing to run against the full dataset every single time.
 
 ### Rendering with full data for publishing
 
-To render and publish with the full dataset (all of this is done locally): 
+To render and publish with the full dataset (all of this is done locally):
 
-* remove the `_freeze/` directory 
-* run `quarto publish gh-pages` 
+* remove the `_freeze/` directory
+* run `quarto publish gh-pages`
 
 This will automatically render the book and then add the files to the `gh-pages` branch where the book is hosted from.
 
@@ -39,7 +39,7 @@ git checkout --no-overlay CI_data -- PUMS_smol
 git restore --staged PUMS_smol
 ```
 
-Which will place the `PUMS_smol` directory in your repo. 
+Which will place the `PUMS_smol` directory in your repo.
 You can then link it to the data directory to be used (e.g. `ln -s PUMS_smol data`)
 
 ### Full data


### PR DESCRIPTION
This PR adds the style sheet and quarto config to render to PDF. Other changes:

* Set `width = 64` globally for PDF, so table/tibble printing is narrower
* Disambiguates footnote anchors, which caused problems for PDF
~~* Temporarily comments out `datasets_pums.png`, which xelatex choked on as too large somehow.~~

Running list of other things we need to fix in the PDF, not comprehensive but just stuff I noticed:

- [x] Many code examples overflow the width. https://github.com/arrowrbook/book/pull/12 solves many (all?) of them, we should probably just merge.
- [ ] There is a warning that our bibliography is empty and we don't have any citations. I think this could just be because we have `bibliography: references.bib` and related bibtex stuff in the `_quarto.yml` file. IDK if we need a bibliography or if our footnote references are ok (I haven't read the style guide). We do have several things in footnotes at least that would be candidates for a proper bibliography.
- [x] We have some weird footnotes within footnotes because of how the PDF is rendering `[anchor](url)`. We either need to change how we do that globally, or find a way to leave that like that for the HTML version and make the PDF handle it differently. _(fixed using conditional logic)_
- [x] index.qmd says "this is the website for...", so that won't work. We need to conditionally hide that bit in the PDF.
- [x] Getting Started plots: title does not fit (should title and subtitle move to fig captions?), line labels overprint each other
- [x] CRS plots (section 8.3.1) have subtitles that overprint
- [ ] Yeah, I think all of the plots need figure numbers and titles and captions governed by quarto, they look off without them.
- [ ] Table 5.2: Comparison of formats supported by Arrow is empty: the ✓ aren't printing. (https://github.com/arrowrbook/book/issues/13 ?)
- [x] Page header has title and BIG SUBTITLE. This comes from the intersection of [this bit](https://github.com/quarto-dev/quarto-cli/blame/adc9e420e91e5a55469fb7ff409d3b3d7baaf0cb/src/resources/formats/pdf/pandoc/title.tex#L9) from the Quarto LaTeX template and how the krantz.cls uses `\maketitle` on the page headers. It's not obvious to me how to work around that, but maybe it's not something we have to resolve, maybe the typesetters will just get that right.
- [ ] We're definitely short on page count :/

Final question: by default, `quarto render` renders all formats, so both html and pdf. You can pick one locally by doing `quarto render --to pdf`. But in CI: do we want to only render HTML? Or, render both, and maybe put the PDF in a build artifact? We probably don't want what I imagine is the default, which renders both and then deploys both--I don't think we want the pdf version of the book on the website. In this PR, I switched it to just do HTML and made https://github.com/arrowrbook/book/issues/17 for us to sort out enabling it.