### PR TITLE
Swap out '✓' for 'x' in format comparison table 

### DIFF
--- a/appendix.qmd
+++ b/appendix.qmd
@@ -292,7 +292,7 @@ tibble::tibble(x = 1:3) |>
 
 #### Translations from R to Arrow {#sec-types-r-arrow}
 
-The following chart is slightly modified from [the Arrow project documentation](https://arrow.apache.org/docs/r/), but clearly marks the mappings between R types and Arrow types.
+@tbl-r-arrow-types is slightly modified from [the Arrow project documentation](https://arrow.apache.org/docs/r/), but clearly marks the mappings between R types and Arrow types.
 
 | Original R type    | Arrow type after translation |
 |--------------------|------------------------------|
@@ -311,6 +311,8 @@ The following chart is slightly modified from [the Arrow project documentation](
 | hms::hms           | time32                       |
 | difftime           | duration                     |
 
+: R data types and their equivalent Arrow data types {#tbl-r-arrow-types}
+
 ^1^: The two types `float64` and `double` are the same in Arrow C++; however, only `float64()` is used in arrow since the function `double()` already exists in base R.
 
 ^2^: If the character vector is exceptionally large---over 2GB of strings---it will be converted to a `large_utf8` Arrow type.
@@ -318,6 +320,8 @@ The following chart is slightly modified from [the Arrow project documentation](
 ^3^: Only lists where all elements are the same type are able to be translated to Arrow list type (which is a "list of" some type). Arrow has a heterogeneous list type, but that is not exposed in the arrow R package.
 
 #### Converting from Arrow to R {#sec-types-arrow-r}
+
+@tbl-arrow-r-types shows Arrow types and the R types they are translated to.
 
 | Original Arrow type | R type after translation    |
 |---------------------|-----------------------------|
@@ -353,6 +357,8 @@ The following chart is slightly modified from [the Arrow project documentation](
 | null                | vctrs::vctrs_unspecified    |
 | map                 | arrow_list ^5^              |
 | union               | \- ^2^                      |
+
+: Arrow data types and their equivalent R data types {#tbl-arrow-r-types}
 
 ^1^: These integer types may contain values that exceed the range of R's `integer` type (32 bit signed integer).
 When they do, `uint32` and `uint64` are converted to `double` ("numeric") and `int64` is converted to `bit64::integer64`.

--- a/cloud.qmd
+++ b/cloud.qmd
@@ -161,11 +161,14 @@ tibble::tibble(max_age = 94L)
 
 An important question to ask here is how long it took to run the query.
 We compared running the same query from above on the same machine---a Posit Cloud instance with 1GB of RAM---with a local copy of the data compared to the cloud version of the same data.
+The results are shown in @tbl-cloud-local.
 
 | Location | Time (s) |
 |----------|----------|
 | Local    |    0.2   |
 | Cloud    |   24.1   |
+
+: Time taken to run the same query on a local machine and connecting to an S3 bucket {#tbl-cloud-local}
 
 There's a huge difference between these results: it was 120 times faster to work with a local copy of the data!
 This was due to the need for data transfer; in the local query, Arrow could just scan the data and perform the necessary calculations, whereas in the cloud query, we needed to download the data first before we could return it to our R session.
@@ -353,13 +356,15 @@ We ran this query on Nic's laptop connecting to the following buckets:
 
 We then tried the queried the original S3 bucket again, but from a Posit Cloud instance deployed on Amazon EC2 in the `us-east-1` region.
 
-The average times across 3 runs are shown in the table below.
+The average times across 3 runs are shown in @tbl-cloud-location.
 
 | Bucket Location          | Access Location          | Time (seconds) |
 |--------------------------|--------------------------|----------------|
 | Virginia, US (us-east-1) | Manchester, UK           | 56             |
 | London, UK (eu-west-2)   | Manchester, UK           | 50             |
 | Virginia, US (us-east-1) | Virginia, US (us-east-1) | 24             |
+
+: Time taken to run the same query with varying bucket location and access location {#tbl-cloud-location}
 
 Using a bucket in the same geographical region resulted in a slight decrease in time to run the query and collect the data, when transferring the results to work with locally.
 However, geographic location alone wasn't the sole factor determining transfer times.

--- a/datasets.qmd
+++ b/datasets.qmd
@@ -114,6 +114,8 @@ In this chapter, we'll be looking at topics relevant to both of these workflows,
 We've already looked at some examples using the `open_dataset()` function.
 The previous examples used Arrow and Parquet datasets, but Arrow supports the same formats for datasets that it does for working with individual files: CSV and similar text-delimited formats, Parquet, Arrow IPC format, and line-delimited JSON.
 
+The different functions for reading and writing datasets are shown in @tbl-dataset-funcs below.
+
 +-----------------------------+--------------------------------------------------------+------------------------------------+
 | Format                      | Reading                                                | Writing                            |
 +:===========================:+:======================================================:+:==================================:+
@@ -125,6 +127,8 @@ The previous examples used Arrow and Parquet datasets, but Arrow supports the sa
 +-----------------------------+--------------------------------------------------------+------------------------------------+
 | Line-delimited JSON         | open_dataset(..., format = "json")                     | (Not supported)                    |
 +-----------------------------+--------------------------------------------------------+------------------------------------+
+
+: Functions for reading and writing datasets {#tbl-dataset-funcs}
 
 The convenience functions `open_csv_dataset()` and `open_delim_dataset()` are wrappers around `open_dataset(..., format = "csv")` but using arguments which match `read_csv_arrow()` and `read_delim_arrow()` to make it easier to switch between working with individual files and multifile datasets by just changing the function call.
 

--- a/datasets.qmd
+++ b/datasets.qmd
@@ -500,7 +500,7 @@ pums_by_year_location_age <- open_dataset(
 )
 ```
 
-The table below shows how many files in each dataset, as well as the minimum, maximum, and median file size.
+@tbl-file-size shows how many files in each dataset, as well as the minimum, maximum, and median file size.
 
 ::: {.content-visible when-format="html"}
 | Dataset                   | \# of Files | Min size  | 1st Quartile | Median size | 3rd Quartile | Max size  |
@@ -509,6 +509,8 @@ The table below shows how many files in each dataset, as well as the minimum, ma
 | pums_by_year              | 34          | 0.1 MB    | 0.1 MB       | 211.8 MB    | 459.9 MB     | 493 MB    |
 | pums_by_year_location     | 1785        | 0.1 MB    | 0.1 MB       | 0.1 MB      | 6.02 MB      | 56.1 MB   |
 | pums_by_year_location_age | 14124       | 0.1 MB    | 0.1 MB       | 0.4 MB      | 1.09 MB      | 17.6 MB   |
+
+: Summary statistics around file sizes of partitioned datasets {#tbl-file-size}
 :::
 
 ::: {.content-visible when-format="pdf"}
@@ -518,6 +520,8 @@ The table below shows how many files in each dataset, as well as the minimum, ma
 | pums_by_year              | 34          | 0.1 MB    | 211.8 MB    | 493 MB    |
 | pums_by_year_location     | 1785        | 0.1 MB    | 0.1 MB      | 56.1 MB   |
 | pums_by_year_location_age | 14124       | 0.1 MB    | 0.4 MB      | 17.6 MB   |
+
+: Summary statistics around file sizes of partitioned datasets {#tbl-file-size}
 :::
 
 ```{r}
@@ -552,7 +556,7 @@ open_dataset("<path/to/data>") |>
   collect()
 ```
 
-Here's the results of running that query on Nic's laptop, with the datasets we created earlier.
+@tbl-partition-query shows the results of running that query on Nic's laptop, with the datasets we created earlier.
 
 | Dataset                   | Query Completion Time (s) |
 |---------------------------|---------------------------|
@@ -560,6 +564,8 @@ Here's the results of running that query on Nic's laptop, with the datasets we c
 | pums_by_year              | 1.0                       |
 | pums_by_year_location     | 1.8                       |
 | pums_by_year_location_age | 6.5                       |
+
+: Time taken to run a query unrelated to dataset partitions, with different partitioning structures {#tbl-partition-query}
 
 In this case, the fastest query time was on the dataset which was partitioned solely by year, the only partition column used in the query.
 In the case of storing the data in one big file, Arrow has to open the file and use the metadata to work out which of the contents to use in the analysis.
@@ -597,7 +603,7 @@ open_dataset("<path/to/data>") |>
   collect()
 ```
 
-We ran it again on Nic's laptop, and these were the results.
+We ran it again on Nic's laptop, and the results are shown in @tbl-partition-query-2.
 
 | Dataset                   | Query Completion Time (s) |
 |---------------------------|---------------------------|
@@ -605,6 +611,8 @@ We ran it again on Nic's laptop, and these were the results.
 | pums_by_year              | 3.2                       |
 | pums_by_year_location     | 3.3                       |
 | pums_by_year_location_age | 11.5                      |
+
+: Time taken to run a query relating to dataset partitions, with different partitioning structures {#tbl-partition-query-2}
 
 The final query was tested without the call to `mutate()` as the column already existed as a partition, but this made little difference to the overall time---too many partitions create an overhead because Arrow has to open too many different files.
 There's a relatively fixed cost to opening and reading any Parquet file, no matter how big that file is.
@@ -654,8 +662,10 @@ Once again, we removed the call to `mutate()` for the dataset which already had 
 | pums_by_year_location     | 2.2                       |
 | pums_by_year_location_age | 0.8                       |
 
+: Time taken to run a query which filters on dataset partitions, with different partitioning structures {#tbl-partition-query-3}
+
 This time the differences were a lot more marked!
-As you can see in the table above, it's the variables most commonly used for filtering which partitions have the most impact on.
+As you can see in @tbl-partition-query-3, it's the variables most commonly used for filtering which partitions have the most impact on.
 
 We don't recommend repartitioning your data every time you want to run a query on your dataset, as the overhead of time spent rewriting the data to disk means it probably won't be worth it.
 What we'd recommend instead is thinking about which variables you use most frequently in calls to `filter()` in your analyses, and store your data in partitions based on these variables.

--- a/files_and_formats.qmd
+++ b/files_and_formats.qmd
@@ -167,6 +167,8 @@ Like we recommend in this chapter: if you're looking for a format to store data 
 
 @tbl-formats summarizes the features and tradeoffs of the file formats that arrow works with.
 
+::: {.content-hidden when-format="pdf"}
+
 |                                 | CSV | ND-JSON | Parquet | Arrow |
 |---------------------------------|-----|---------|---------|-------|
 | Read using Arrow                | ✓   | ✓       | ✓       | ✓     |
@@ -181,6 +183,24 @@ Like we recommend in this chapter: if you're looking for a format to store data 
 | Widely adopted                  | ✓   |         | ✓       |       |
 
 : Comparison of formats supported by Arrow {#tbl-formats}
+:::
+::: {.content-hidden when-format="html"}
+
+|                                 | CSV | ND-JSON | Parquet | Arrow |
+|---------------------------------|-----|---------|---------|-------|
+| Read using Arrow                | x   | x       | x       | x     |
+| Write using Arrow               | x   |         | x       | x     |
+| Human-readable                  | x   | x       |         |       |
+| Fast read/write                 |     |         | x       | x     |
+| Includes schema                 |     |         | x       | x     |
+| Metadata                        |     |         | x       | x     |
+| Nested structures               |     | x       | x       | x     |
+| Compression                     |     |         | x       | x     |
+| High-fidelity type preservation |     |         | x       | x     |
+| Widely adopted                  | x   |         | x       |       |
+
+: Comparison of formats supported by Arrow {#tbl-formats}
+:::
 
 Now that we've surveyed the file formats, we're going to discuss how to read in CSVs effectively since they are both widespread and potentially challenging.
 We'll also demonstrate why exactly Parquet files are beneficial in terms of file size, speed, and fidelity, and show you how to convert your CSV data into Parquet files.

--- a/files_and_formats.qmd
+++ b/files_and_formats.qmd
@@ -40,7 +40,7 @@ Arrow supports reading and writing files in multiple formats:
 -   Parquet
 -   the Arrow format itself
 
-The functions for reading and writing individual files in arrow are shown in the table below.
+The functions for reading and writing individual files in arrow are shown in @tbl-file-funcs.
 
 +-------------------------------------+-----------------------+----------------------+
 | Format                              | Reading               | Writing              |
@@ -61,6 +61,8 @@ The functions for reading and writing individual files in arrow are shown in the
 |                                     |                       |                      |
 |                                     | read_feather()        | write_feather()      |
 +-------------------------------------+-----------------------+----------------------+
+
+: Functions for reading and writing individual files {#tbl-file-funcs}
 
 Let's briefly review the file formats.
 

--- a/files_and_formats.qmd
+++ b/files_and_formats.qmd
@@ -183,6 +183,7 @@ Like we recommend in this chapter: if you're looking for a format to store data 
 | Widely adopted                  | ✓   |         | ✓       |       |
 
 : Comparison of formats supported by Arrow {#tbl-formats}
+
 :::
 ::: {.content-hidden when-format="html"}
 
@@ -200,6 +201,7 @@ Like we recommend in this chapter: if you're looking for a format to store data 
 | Widely adopted                  | x   |         | x       |       |
 
 : Comparison of formats supported by Arrow {#tbl-formats}
+
 :::
 
 Now that we've surveyed the file formats, we're going to discuss how to read in CSVs effectively since they are both widespread and potentially challenging.
@@ -808,6 +810,7 @@ You can use `arrow::arrow_info()` to see a full list of codecs and other capabil
 Let's take a look at the degree of difference between an uncompressed CSV file, uncompressed Parquet file, compared to "snappy", the default on Linux, and "zstd", one of the current top-performing codecs.
 
 We wrote the files to disk, and then read in just the "AGEP", "COW", and "year" columns.
+The results can be see in @tbl-format-bench.
 
 |         Format         |  Size  | Write time | Read time |
 |:----------------------:|:------:|:----------:|-----------|
@@ -815,6 +818,8 @@ We wrote the files to disk, and then read in just the "AGEP", "COW", and "year" 
 | Parquet - uncompressed | 37.1MB |   14.89s   | 9.215s    |
 |    Parquet - snappy    | 35.8MB |  15.378s   | 10.051s   |
 |     Parquet - zstd     | 30.7MB |  15.203s   | 9.942s    |
+
+: Comparison of file size, read and write times for CSV and Parquet {#tbl-format-bench}
 
 Ultimately, the different Parquet codecs results in similar performance for read and write times with the data here, though this can vary massively based on the data being written/read.
 The key points to take away here are:


### PR DESCRIPTION
I've swapped out ticks for `x` in the table in the PDF version - seemed like the simplest solution.

Closes #13 
Closes #32 