### PR TITLE
Fix numbering of frontmatter 

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -3,20 +3,6 @@ project:
   output-dir: _book
 
 book:
-  title: "Scaling Up With R and Arrow"
-  subtitle: "Bigger Data, Easier Workflows"
-  author: "Nic Crane, Jonathan Keane, and Neal Richardson"
-  reader-mode: true
-  google-analytics: "G-4JT42QR6DV"
-
-
-  page-footer:
-    left: |
-      Scaling Up With R and Arrow was written by Nic Crane, Jonathan Keane,
-      and Neal Richardson.
-    right: |
-      This book was built with <a href="https://quarto.org/">Quarto</a>.
-
   chapters:
     - index.qmd
     - foreword.qmd
@@ -40,6 +26,17 @@ format:
     df-print: paged
     fig-width: 8
     fig-height: 6
+    title: "Scaling Up With R and Arrow"
+    subtitle: "Bigger Data, Easier Workflows"
+    author: "Nic Crane, Jonathan Keane, and Neal Richardson"
+    reader-mode: true
+    google-analytics: "G-4JT42QR6DV"
+    page-footer:
+      left: |
+        Scaling Up With R and Arrow was written by Nic Crane, Jonathan Keane,
+        and Neal Richardson.
+      right: |
+        This book was built with <a href="https://quarto.org/">Quarto</a>.
   pdf:
     toc: false
     toc-title: "Contents"
@@ -50,8 +47,8 @@ format:
     classoption: [krantz2]
     fig-width: 6
     # fig-height: 9
-    format-resources:
-      - latex/krantz.cls
+    # format-resources:
+    #   - latex/krantz.cls
     hyperrefoptions: "bookmarks=false"
     links-as-notes: true
     colorlinks: false

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -64,6 +64,7 @@ format:
       text: |
         \usepackage{fvextra}
         \DefineVerbatimEnvironment{Highlighting}{Verbatim}{breaklines,commandchars=\\\{\}}
+        \frontmatter
     include-before-body:
       text: |
         \RecustomVerbatimEnvironment{verbatim}{Verbatim}{

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -3,6 +3,9 @@ project:
   output-dir: _book
 
 book:
+  # we may need to comment the title out when rendering final version to pdf
+  # but it breaks the chapter titles in sidebar in the html if we move it to that section
+  title: "Scaling Up With R and Arrow"
   chapters:
     - index.qmd
     - foreword.qmd
@@ -26,7 +29,6 @@ format:
     df-print: paged
     fig-width: 8
     fig-height: 6
-    title: "Scaling Up With R and Arrow"
     subtitle: "Bigger Data, Easier Workflows"
     author: "Nic Crane, Jonathan Keane, and Neal Richardson"
     reader-mode: true

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -47,8 +47,8 @@ format:
     classoption: [krantz2]
     fig-width: 6
     # fig-height: 9
-    # format-resources:
-    #   - latex/krantz.cls
+    format-resources:
+      - latex/krantz.cls
     hyperrefoptions: "bookmarks=false"
     links-as-notes: true
     colorlinks: false
@@ -62,15 +62,8 @@ format:
         \usepackage{fvextra}
         \DefineVerbatimEnvironment{Highlighting}{Verbatim}{breaklines,commandchars=\\\{\}}
         \frontmatter
-    include-before-body:
-      text: |
-        \RecustomVerbatimEnvironment{verbatim}{Verbatim}{
-          showspaces = false,
-          showtabs = false,
-          breaksymbolleft={},
-          breaklines
-          % Note: setting commandchars=\\\{\} here will cause an error 
-        }
+    include-before-body: latex/before_body.tex
+        
     # highlight-style: grayscale-custom.theme
     # include-in-header: latex/preamble.tex
     # include-before-body: latex/before_body.tex

--- a/foreword.qmd
+++ b/foreword.qmd
@@ -1,4 +1,4 @@
-# Foreword
+# Foreword {.unnumbered}
 
 **Foreword by Wes McKinney**
 

--- a/foreword.qmd
+++ b/foreword.qmd
@@ -1,4 +1,4 @@
-# Foreword {.unnumbered}
+# Foreword {.unnumbered .unlisted}
 
 **Foreword by Wes McKinney**
 
@@ -31,3 +31,9 @@ These questions led us to create the Apache Arrow open-source project, a new kin
 This book teaches you how to use the R Arrow library, which is a product of all of this work that started almost a decade ago. In addition to providing you with fast, scalable computing capabilities, it is also a foundation for using other Arrow-powered data processing tools like DuckDB or DataFusion and any others that may be developed in the future. Arrow for R builds on top of a common C++-based library foundation also used in Python and Ruby, as well as many other open-source and proprietary systems that incorporate the Arrow C++ library. The authors of this book are some of the leading developers of the Arrow R library: they have spent several years creating a thoughtful and intuitive experience to help R developers level up their data processing capabilities. 
 
 As a co-creator of Arrow, I am excited for books like this to be written and to showcase the benefits of the work done by the Arrow open-source community. The tools within will serve you well and expand your use of R to work with large-scale datasets efficiently. 
+
+```{=latex}
+\pagenumbering{arabic}
+\mainmatter
+\setcounter{chapter}{0}
+```

--- a/index.qmd
+++ b/index.qmd
@@ -4,6 +4,6 @@ This is the website for Scaling Up with R and Arrow.
 
 :::
 
-# Acknowledgements {.unnumbered}
+# Acknowledgements {.unnumbered .unlisted}
 
 A huge thanks to folks who gave us writing advice and really helpful feedback on our drafts of this book, including Sam Albers, Carl Boettiger, Raúl Cumplido, Dewey Dunnington, Alenka Frim, Colin Gillespie, Stephanie Hazlitt, Jared Lander, Bryce Mecum, François Michonneau, Danielle Navarro, Antoine Pitrou, Brian Repko, and Jacob Wujciak-Jens.

--- a/intro.qmd
+++ b/intro.qmd
@@ -1,3 +1,7 @@
+```{=latex}
+\mainmatter
+\setcounter{chapter}{1}
+```
 
 ```{r}
 #| label: intro-chapter-setup

--- a/intro.qmd
+++ b/intro.qmd
@@ -1,8 +1,3 @@
-```{=latex}
-\mainmatter
-\setcounter{chapter}{1}
-```
-
 ```{r}
 #| label: intro-chapter-setup
 #| include: false

--- a/latex/before_body.tex
+++ b/latex/before_body.tex
@@ -1,0 +1,33 @@
+\RecustomVerbatimEnvironment{verbatim}{Verbatim}{
+          showspaces = false,
+          showtabs = false,
+          breaksymbolleft={},
+          breaklines
+          % Note: setting commandchars=\\\{\} here will cause an error 
+}
+
+\pagenumbering{roman}
+
+\frontmatter
+
+\halftitle{Scaling Up With R and Arrow}{This is a placeholder page for the standard blurb added later}
+
+\title{Scaling Up With R and Arrow}
+
+\edition{First Edition}
+
+\author{
+Nic Crane\\
+Jonathan Keane\\
+Neal Richardson
+}
+
+\maketitle
+
+\locpage
+
+\cleardoublepage
+\setcounter{page}{5} 
+\renewcommand{\contentsname}{Contents}
+\tableofcontents
+

--- a/latex/krantz.cls
+++ b/latex/krantz.cls
@@ -1,11 +1,11 @@
 %%
 %% This is file `Krantz.cls'
-%%% Created by Shashi Kumar / ITC [August 2008]
+%%% Created by Shashi Kumar / KGL [Jan 2023]
 
 
 \NeedsTeXFormat{LaTeX2e}[1995/12/01]
 \ProvidesClass{krantz}
-              [2005/09/16 v1.4f
+              [2021/10/04 v1.4n
  Standard LaTeX document class]
 \newcommand\@ptsize{}
 \newif\if@restonecol
@@ -14,47 +14,47 @@
 \newif\if@openright
 \newif\if@mainmatter \@mainmattertrue
 \if@compatibility\else
-\DeclareOption{a4paper}
-   {\setlength\paperheight {297mm}%
-    \setlength\paperwidth  {210mm}}
-\DeclareOption{a5paper}
-   {\setlength\paperheight {210mm}%
-    \setlength\paperwidth  {148mm}}
-\DeclareOption{b5paper}
-   {\setlength\paperheight {250mm}%
-    \setlength\paperwidth  {176mm}}
-\DeclareOption{letterpaper}
-   {\setlength\paperheight {11in}%
-    \setlength\paperwidth  {8.5in}}
-\DeclareOption{legalpaper}
-   {\setlength\paperheight {14in}%
-    \setlength\paperwidth  {8.5in}}
-\DeclareOption{executivepaper}
-   {\setlength\paperheight {10.5in}%
-    \setlength\paperwidth  {7.25in}}
-\DeclareOption{landscape}
-   {\setlength\@tempdima   {\paperheight}%
-    \setlength\paperheight {\paperwidth}%
-    \setlength\paperwidth  {\@tempdima}}
+  \DeclareOption{a4paper}
+     {\setlength\paperheight {297mm}%
+      \setlength\paperwidth  {210mm}}
+  \DeclareOption{a5paper}
+     {\setlength\paperheight {210mm}%
+      \setlength\paperwidth  {148mm}}
+  \DeclareOption{b5paper}
+     {\setlength\paperheight {250mm}%
+      \setlength\paperwidth  {176mm}}
+  \DeclareOption{letterpaper}
+     {\setlength\paperheight {11in}%
+      \setlength\paperwidth  {8.5in}}
+  \DeclareOption{legalpaper}
+     {\setlength\paperheight {14in}%
+      \setlength\paperwidth  {8.5in}}
+  \DeclareOption{executivepaper}
+     {\setlength\paperheight {10.5in}%
+      \setlength\paperwidth  {7.25in}}
+  \DeclareOption{landscape}
+     {\setlength\@tempdima   {\paperheight}%
+      \setlength\paperheight {\paperwidth}%
+      \setlength\paperwidth  {\@tempdima}}
 \fi
 \if@compatibility
   \renewcommand\@ptsize{0}
 \else
-\DeclareOption{10pt}{\renewcommand\@ptsize{0}}
+  \DeclareOption{10pt}{\renewcommand\@ptsize{0}}
 \fi
 \DeclareOption{11pt}{\renewcommand\@ptsize{1}}
 \DeclareOption{12pt}{\renewcommand\@ptsize{2}}
 \if@compatibility\else
-\DeclareOption{oneside}{\@twosidefalse \@mparswitchfalse}
+  \DeclareOption{oneside}{\@twosidefalse \@mparswitchfalse}
 \fi
 \DeclareOption{twoside}{\@twosidetrue  \@mparswitchtrue}
 \DeclareOption{draft}{\setlength\overfullrule{5pt}}
 \if@compatibility\else
-\DeclareOption{final}{\setlength\overfullrule{0pt}}
+  \DeclareOption{final}{\setlength\overfullrule{0pt}}
 \fi
 \DeclareOption{titlepage}{\@titlepagetrue}
 \if@compatibility\else
-\DeclareOption{notitlepage}{\@titlepagefalse}
+  \DeclareOption{notitlepage}{\@titlepagefalse}
 \fi
 \if@compatibility
 \@openrighttrue
@@ -63,22 +63,24 @@
 \DeclareOption{openany}{\@openrightfalse}
 \fi
 \if@compatibility\else
-\DeclareOption{onecolumn}{\@twocolumnfalse}
+  \DeclareOption{onecolumn}{\@twocolumnfalse}
 \fi
 \DeclareOption{twocolumn}{\@twocolumntrue}
 \DeclareOption{leqno}{\input{leqno.clo}}
 \DeclareOption{fleqn}{\input{fleqn.clo}}
 \DeclareOption{openbib}{%
   \AtEndOfPackage{%
-   \renewcommand\@openbib@code{%
+    \renewcommand\@openbib@code{%
       \advance\leftmargin\bibindent
       \itemindent -\bibindent
       \listparindent \itemindent
       \parsep \z@
       }%
-   \renewcommand\newblock{\par}}%
+    \renewcommand\newblock{\par}}%
 }
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+
+%%%%%%%%%%%
 \newif\if@numbysec
 \DeclareOption{numbysec}{\@numbysectrue}
 \newif\if@numberinsequence
@@ -109,11 +111,12 @@
 \newif\if@krantza
 \DeclareOption{krantz2}{\@krantzbtrue}
 \newif\if@krantzb
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%%%%%%%%%%%%%%%%%
 
 
 \ExecuteOptions{letterpaper,10pt,twoside,onecolumn,final,openright}
 \ProcessOptions
+
 
 %%%%%%%%%%%%%%%%%%%
 
@@ -160,9 +163,10 @@
 \newcommand\ContributorNameFont{\reset@font\fontsize{10}{12}\bfseries\raggedright\selectfont}
 
 \newcommand\TitlePageTitleFont{\fontsize{24}{28}\slshape\bfseries\selectfont}
+\newcommand\TitlePageSubtitleFont{\fontsize{21}{26}\slshape\selectfont}
 \newcommand\PageNumFont{\reset@font\fontsize{10}{12}\selectfont}
 \newcommand\ChapNumFont{\reset@font\fontsize{24}{24}\bfseries\selectfont}
-\newcommand\ChapTitleFont{\reset@font\fontsize{18}{20}\slshape\selectfont}
+\newcommand\ChapTitleFont{\reset@font\fontsize{24}{26}\slshape\selectfont}
 \newcommand\SectionHeadFont{\fontsize{12}{14}\bfseries\selectfont}
 \newcommand\SubsectionHeadFont{\fontsize{11}{13}\bfseries\selectfont}
 \newcommand\SubsubsectionHeadFont{\fontsize{10}{12}\bfseries\selectfont}
@@ -170,7 +174,8 @@
 \newcommand\SubParagraphHeadFont{\fontsize{10}{12}\itshape\selectfont}
 \newcommand\FMHeadFont{\reset@font\fontsize{18}{20}\slshape\bfseries\selectfont}
 \newcommand\RunningHeadFont{\fontsize{10}{12}\itshape\selectfont}
-\newcommand\NameFont{\fontsize{10}{12}\itshape\selectfont}
+\newcommand\NameFont{\fontsize{14}{18}\itshape\selectfont}
+\newcommand\EdFont{\fontsize{14}{18}\selectfont}
 \newcommand\AffiliationFont{\fontsize{8}{10}\selectfont}
 \newcommand\FigCapFont{\fontsize{10}{12}\bfseries\selectfont}
 \newcommand\FigCapBIFont{\fontsize{10}{12}\bfseries\itshape\selectfont}
@@ -188,6 +193,8 @@
 
 %%%%%%%%%%%%%%%%%
 
+
+
 \input{bk1\@ptsize.clo}
 \setlength\lineskip{1\p@}
 \setlength\normallineskip{1\p@}
@@ -196,12 +203,6 @@
 \@lowpenalty   51
 \@medpenalty  151
 \@highpenalty 301
-\@beginparpenalty -\@lowpenalty
-\@endparpenalty   -\@lowpenalty
-\@itempenalty     -\@lowpenalty
-%
-\clubpenalty=0         % 'Club line'  at bottom of page.
-\widowpenalty=10000    % 'Widow line' at top of page.
 \setcounter{topnumber}{2}
 \renewcommand\topfraction{.7}
 \setcounter{bottomnumber}{1}
@@ -212,6 +213,7 @@
 \setcounter{dbltopnumber}{2}
 \renewcommand\dbltopfraction{.7}
 \renewcommand\dblfloatpagefraction{.5}
+
 
 %  ****************************************
 %  *            PAGE LAYOUT               *
@@ -244,9 +246,10 @@
 \newdimen\vtrimtop
 \newdimen\vtrimbot
 
-\setlength\trimheight{9in}
-\setlength\trimwidth{6in}
+\setlength\trimheight{9.21in}
+\setlength\trimwidth{6.14in}
 %
+
 %
 \if@krantza
 \textheight = 45pc
@@ -345,54 +348,44 @@
      \def\@oddfoot{\reset@font\hfil\thepage
      \hfil}\let\@evenhead\@empty\let\@evenfoot\@oddfoot}
 
-
-
-\def\even@head{%
-\top@cornermarks
-  {\@the@page\RunningHeadFont
-    \hfill
-\leftmark
-    }}
-\def\odd@head{%
-\top@cornermarks
-  \hfil{\RunningHeadFont
-\rightmark
-    }
-\hfill
-    \@the@page
-  }
-\def\@the@page{{\PageNumFont\thepage}}
+%%%%
 
 
 \if@twoside
-\def\ps@headings{%
+  \def\ps@headings{%
   \let\@mkboth\@gobbletwo
-  \if@pdf
-    \let\@evenhead\@empty
-    \let\@oddhead\@empty
-    \def\@oddfoot{\@cip\hfil}%
-    \def\@evenfoot{\@cip\hfil}%
-  \else
-\let\@oddfoot\@empty
-\let\@evenfoot\@empty
-    \let\@evenhead\even@head
-    \let\@oddhead\odd@head
-  \fi
-  }
+      \let\@oddfoot\@empty\let\@evenfoot\@empty
+      \def\@evenhead{\top@cornermarks{\PageNumFont\thepage}\hfil\RunningHeadFont\leftmark}%
+      \def\@oddhead{\top@cornermarks{\RunningHeadFont\rightmark}\hfil{\PageNumFont\thepage}}%
+      \let\@mkboth\markboth
+%    \def\chaptermark##1{%
+%      \markboth {{%\MakeUppercase
+%        \ifnum \c@secnumdepth >\m@ne
+%          \if@mainmatter
+%%            \@chapapp\ \thechapter. \ %
+%          \fi
+%        \fi
+%        ##1}}{}}%
+%    \def\sectionmark##1{%
+%      \markright {{%\MakeUppercase
+%        \ifnum \c@secnumdepth >\z@
+%%          \thesection. \ %
+%        \fi
+%        ##1}}}
+        }
 \else
-  \def\ps@headings{\let\@mkboth\@gobbletwo%
-\if@pdf
-    \let\@evenhead\@empty
-    \let\@oddhead\@empty
-    \def\@oddfoot{\@cip\hfil}%
-    \def\@evenfoot{\@cip\hfil}%
-  \else
-\let\@oddfoot\@empty
-\let\@evenfoot\@empty
-    \let\@evenhead\even@head
-    \let\@oddhead\odd@head
-  \fi
-}
+  \def\ps@headings{%
+    \let\@oddfoot\@empty
+    \def\@oddhead{{\slshape\rightmark}\hfil\thepage}%
+    \let\@mkboth\markboth
+    \def\chaptermark##1{%
+      \markright {{%\MakeUppercase
+        \ifnum \c@secnumdepth >\m@ne
+          \if@mainmatter
+            \@chapapp\ \thechapter. \ %
+          \fi
+        \fi
+        ##1}}}}
 \fi
 \def\ps@myheadings{%
     \let\@oddfoot\@empty\let\@evenfoot\@empty
@@ -402,6 +395,8 @@
     \let\chaptermark\@gobble
     \let\sectionmark\@gobble
     }
+    
+    
 \def\ps@empty{%
   \let\@mkboth\@gobbletwo
   \if@pdf
@@ -418,7 +413,7 @@
   \fi
   }
 \def\ps@folio{%
-  \let\@mkboth\@gobbletwo
+  \let\@mkboth\@gobbletwo\make@cornermarks
   \if@pdf
     \let\@evenhead\@empty
     \let\@oddhead\@empty
@@ -434,7 +429,7 @@
         \vbox{%
           \if@cip\rule{\@ciprulewidth}{.25pt}\par
             \hbox{\vbox{\noindent\copy\@cipboxa\par\noindent\copy\@cipboxb}}\fi}}
-      \hfill\@the@page}
+      \hfill\thepage}
     \let\@evenhead\top@cornermarks%\odd@head
     \let\@evenfoot\@oddfoot
   \fi
@@ -471,21 +466,35 @@
     \@cip{\rule{0pt}{9pt}0-8493-0052-5/00/\$0.00+\$.50}%
       {\copyright\ \ 2001 by CRC Press LLC}}%
 \fi
-  \if@titlepage
+
+\DeclareRobustCommand\subtitle[1]{\gdef\@subtitle{#1}}
+\DeclareRobustCommand\edition[1]{\gdef\@edition{#1}}
+\DeclareRobustCommand\editor[1]{\gdef\@editor{Edited by #1}}
+\def\@subtitle{}
+\def\@editor{}
+\def\@edition{}
+
+    
+\if@titlepage
   \newcommand\maketitle{\begin{titlepage}%
   \let\footnotesize\small
   \let\footnoterule\relax
   \let \footnote \thanks
 {\parindent \z@ \raggedright \baselineskip \z@ \lineskip \z@ \parskip \z@
     \vbox{
-    \vskip -7bp
-    {\baselineskip 10bp\lineskip 10bp\NameFont\uppercase{\@author}\par}
+%    \crcrule
+%    \vskip 22bp
+    {\baselineskip 24bp\lineskip 24bp\TitlePageTitleFont\@title\par}
+    \vskip 27bp
+    {\baselineskip 10bp\lineskip 10bp\TitlePageSubtitleFont{\@subtitle}\par}
+    \vskip 107bp
+    {\baselineskip 10bp\lineskip 10bp\EdFont{\@edition}\par}
+    \vskip 127bp
+    {\baselineskip 10bp\lineskip 10bp\NameFont{\@author}\par}
+    {\baselineskip 10bp\lineskip 10bp\NameFont{\@editor}\par}
     \vskip 6bp
     \AffiliationFont \@affiliation
-    \vskip -2bp
-    \crcrule
-    \vskip 22bp
-    {\baselineskip 24bp\lineskip 24bp\TitlePageTitleFont\@title\par}}}
+    \vskip -2bp}}
   \@thanks
   \vfil\null
   \end{titlepage}%
@@ -500,63 +509,60 @@
   \global\let\author\relax
   \global\let\date\relax
   \global\let\and\relax
-}
+  }
 \else
-\newcommand\maketitle{\par
-  \begingroup
-    \renewcommand\thefootnote{\@fnsymbol\c@footnote}%
-    \def\@makefnmark{\rlap{\@textsuperscript{\normalfont\@thefnmark}}}%
-    \long\def\@makefntext##1{\parindent 1em\noindent
-            \hb@xt@1.8em{%
+  \newcommand\maketitle{\par
+    \begingroup
+      \renewcommand\thefootnote{\@fnsymbol\c@footnote}%
+      \def\@makefnmark{\rlap{\@textsuperscript{\normalfont\@thefnmark}}}%
+      \long\def\@makefntext##1{\parindent 1em\noindent
+              \hb@xt@1.8em{%
                 \hss\@textsuperscript{\normalfont\@thefnmark}}##1}%
-    \if@twocolumn
-      \ifnum \col@number=\@ne
-        \@maketitle
+      \if@twocolumn
+        \ifnum \col@number=\@ne
+          \@maketitle
+        \else
+          \twocolumn[\@maketitle]%
+        \fi
       \else
-        \twocolumn[\@maketitle]%
-      \fi
-    \else
       \newpage
-      \global\@topnum\z@   % Prevents figures from going at top of page.
-      \@maketitle
-    \fi
-    \thispagestyle{empty}\@thanks
-  \endgroup
-  \setcounter{footnote}{0}%
-  \global\let\thanks\relax
-  \global\let\maketitle\relax
-  \global\let\@maketitle\relax
-  \global\let\@thanks\@empty
-  \global\let\@author\@empty
-  \global\let\@date\@empty
-  \global\let\@title\@empty
-  \global\let\title\relax
-  \global\let\author\relax
-  \global\let\date\relax
-  \global\let\and\relax
-}
+        \global\@topnum\z@   % Prevents figures from going at top of page.
+        \@maketitle
+      \fi
+      \thispagestyle{empty}\@thanks
+    \endgroup
+    \setcounter{footnote}{0}%
+    \global\let\thanks\relax
+    \global\let\maketitle\relax
+    \global\let\@maketitle\relax
+    \global\let\@thanks\@empty
+    \global\let\@author\@empty
+    \global\let\@date\@empty
+    \global\let\@title\@empty
+    \global\let\title\relax
+    \global\let\author\relax
+    \global\let\date\relax
+    \global\let\and\relax
+  }
 \def\@maketitle{%
   \newpage
   \null
   \vskip 2em%
-{\parindent \z@ \raggedright \baselineskip \z@ \lineskip \z@ \parskip \z@
-    \vbox{
-    \vskip -7bp
-    {\baselineskip 10bp\lineskip 10bp\NameFont\uppercase{\@author}\par}
-    \vskip 6bp
-    \AffiliationFont \@affiliation
-    \vskip 10bp
-    \crcrule
-    \vskip 26bp
-    {\baselineskip 24bp\lineskip 24bp\TitlePageTitleFont\@title\par}}}
+  \begin{center}%
+  \let \footnote \thanks
+    {\LARGE \@title \par}%
+    \vskip 1.5em%
+    {\large
+      \lineskip .5em%
+      \begin{tabular}[t]{c}%
+        \@author
+      \end{tabular}\par}%
+    \vskip 1em%
+    {\large \@date}%
+  \end{center}%
   \par
   \vskip 1.5em}
 \fi
-
-
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-
-
 \newcommand*\chaptermark[1]{}
 \setcounter{secnumdepth}{3}
 \newcounter {part}
@@ -570,10 +576,15 @@
 \renewcommand \thechapter {\@arabic\c@chapter}
 \renewcommand \thesection {\thechapter.\@arabic\c@section}
 \renewcommand\thesubsection   {\thesection.\@arabic\c@subsection}
-\renewcommand\thesubsubsection{\thesubsection .\@arabic\c@subsubsection}
+\renewcommand\thesubsubsection{\thesubsection.\@arabic\c@subsubsection}
 \renewcommand\theparagraph    {\thesubsubsection.\@arabic\c@paragraph}
 \renewcommand\thesubparagraph {\theparagraph.\@arabic\c@subparagraph}
 \newcommand\@chapapp{\chaptername}
+
+\newbox\tempbox%
+\newdimen\tempdimen%
+
+
 \newcommand\frontmatter{%
     \cleardoublepage
   \@mainmatterfalse
@@ -589,7 +600,7 @@
     \clearpage
   \fi
   \@mainmatterfalse}
-\newcommand\part{\make@cornermarks%
+\newcommand\part{%
   \if@openright
     \cleardoublepage
   \else
@@ -640,7 +651,8 @@
               \if@tempswa
                 \twocolumn
               \fi}
-
+              
+              
 \if@ChapterTOCs
   \newwrite\@chaptoc
    \def\secnumwidth{21pt}\def\subsecnumwidth{30pt}\def\ssubsecnumwidth{36pt}\def\subsubsecnumwidth{66pt}\fi
@@ -649,41 +661,40 @@
 \long\def\@ytrplarg#1[#2]#3{#1[{#2}][{#2}]{#3}}
 \long\def\@ztrplarg#1#2{#1[{#2}][{#2}]{#2}}
 
-\def\halftitle{\cleardoublepage\thispagestyle{empty}%
+\newcommand\halftitle[2]{\cleardoublepage\thispagestyle{empty}%
   {\parindent \z@ \raggedright \baselineskip \z@ \lineskip \z@ \parskip \z@
     \vbox{
     \vskip -2\p@
     \ChapNumFont
-%    \thechapter
-    \vskip -15\p@
-    \chap@rule
-    \vskip 6\p@
-    {\baselineskip 20\p@\lineskip 20\p@\ChapTitleFont Half Title\par\vskip-15pt}%
-    \noindent\hbox{\vrule height.5pt width84pt}
+    {\baselineskip 20\p@\lineskip 20\p@\ChapTitleFont #1\par\vskip15pt}%
+   {\normalsize\normalfont #2}
+%    \noindent\hbox{\vrule height.5pt width84pt}
     \vskip28\p@}
-            \if@ChapterTOCs
-      \make@chaptoc
-    \else
-\fi
     \vskip 19.3\p@}
     }%
 
-\def\booktitle{\cleardoublepage\thispagestyle{empty}%
+\newcommand\seriespg[1]{\clearpage\thispagestyle{empty}%
   {\parindent \z@ \raggedright \baselineskip \z@ \lineskip \z@ \parskip \z@
     \vbox{
     \vskip -2\p@
     \ChapNumFont
-%    \thechapter
-    \vskip -15\p@
-    \chap@rule
-    \vskip 6\p@
-    {\baselineskip 20\p@\lineskip 20\p@\ChapTitleFont Title Page\par\vskip-15pt}%
-    \noindent\hbox{\vrule height.5pt width84pt}
+    {\baselineskip 20\p@\lineskip 20\p@\Large #1\par\vskip15pt}%
+%   {\normalsize #2}
+%    \noindent\hbox{\vrule height.5pt width84pt}
     \vskip28\p@}
-            \if@ChapterTOCs
-      \make@chaptoc
-    \else
-\fi
+    \vskip 19.3\p@}
+    }%
+    
+\newcommand\booktitle[2]{\cleardoublepage\thispagestyle{empty}%
+  {\parindent \z@ \raggedright \baselineskip \z@ \lineskip \z@ \parskip \z@
+    \vbox{
+    \vskip -2\p@
+    \ChapNumFont
+    \vskip 6\p@
+    {\baselineskip 20\p@\lineskip 20\p@\ChapTitleFont #1\par\vskip-15pt}%
+%    \noindent\hbox{\vrule height.5pt width84pt}
+{#2}
+    \vskip28\p@}
     \vskip 19.3\p@}
     }%
 
@@ -692,59 +703,78 @@
     \vbox{
     \vskip -2\p@
     \ChapNumFont
-%    \thechapter
-    \vskip -15\p@
-    \chap@rule
-    \vskip 6\p@
-    {\baselineskip 20\p@\lineskip 20\p@\ChapTitleFont LOC Page\par\vskip-15pt}%
-    \noindent\hbox{\vrule height.5pt width84pt}
+    {\baselineskip 20\p@\lineskip 20\p@\Large Imprint page here; PE will provide text\par\vskip-15pt}%
+%    \noindent\hbox{\vrule height.5pt width84pt}
     \vskip28\p@}
-            \if@ChapterTOCs
-      \make@chaptoc
-    \else
-\fi
     \vskip 19.3\p@}
 }%
 
 
+
+%\newif\if@afterindent \@afterindenttrue
+\def\@afterheading{%
+  \@nobreaktrue
+  \everypar{%
+    \if@nobreak
+      \@nobreakfalse
+      \clubpenalty \@M
+      \if@afterindent \else
+        {\setbox\z@\lastbox}%
+      \fi
+    \else
+      \clubpenalty \@clubpenalty
+      \everypar{}%
+    \fi}}
+
+              
 \newcommand\chapter{\if@openright\cleardoublepage\else\clearpage\fi
-  \make@cornermarks
+\make@cornermarks
   \cleardoublepage
   \if@ChapterTOCs\if@filesw\immediate\closeout\@chaptoc\fi\fi
   \pagestyle{headings}%
-  \thispagestyle{folio}%
+                    \thispagestyle{folio}%
 \if@ChapterResetsPage\global\c@page\@ne\fi
                     \global\@topnum\z@
                       \gdef\chapterauthor{\@ca}%
   \gdef\endchapterauthors{\end@cas}%
                     \@afterindentfalse
-                    \secdef\@chapter\@schapter
-%%%                     \@ifstar{\@schapter}{\@trplarg{\@chapter}}
-                     }
-
-
-\def\@chapter[#1]#2{%
-  \ifnum\c@secnumdepth>\m@ne
-    \if@mainmatter
-      \refstepcounter{chapter}%
-      \typeout{\@chapapp\space\thechapter.}%
-      \addcontentsline{toc}{chapter}{\protect\numberline{\thechapter}#1}%
-    \else
-      \addcontentsline{toc}{chapter}{#1}\fi
-  \else
-    \addcontentsline{toc}{chapter}{#1}\fi
-  \chaptermark{%
-    #2}%
-  \addtocontents{lof}{\protect\addvspace{10\p@}}%
-  \addtocontents{lot}{\protect\addvspace{10\p@}}%
-  \if@twocolumn
-    \@topnewpage[\@makechapterhead{#2}]%
-  \else
-    \@makechapterhead{#2}%
-    \@afterheading\fi
+                    \secdef\@chapter\@schapter}
+\def\@chapter[#1]#2{\ifnum \c@secnumdepth >\m@ne
+                       \if@mainmatter
+                         \refstepcounter{chapter}%
+                         \typeout{\@chapapp\space\thechapter.}%
+                         \addcontentsline{toc}{chapter}%
+                                   {\protect\numberline{\thechapter}#1}%
+                       \else
+                         \addcontentsline{toc}{chapter}{#1}%
+                       \fi
+                    \else
+                      \addcontentsline{toc}{chapter}{#1}%
+                    \fi
+                    \chaptermark{#1}%
+                    \addtocontents{lof}{\protect\addvspace{10\p@}}%
+                    \addtocontents{lot}{\protect\addvspace{10\p@}}%
+                    \if@twocolumn
+                      \@topnewpage[\@makechapterhead{#2}]%
+                    \else
+                      \@makechapterhead{#2}%
+                      \@afterheading
+                    \fi
   \if@ChapterTOCs\if@filesw\immediate\openout\@chaptoc\thechapter.toc\fi\fi
-}
+                    }
 \def\@makechapterhead#1{%
+%%  \vspace*{50\p@}%
+%%  {\parindent \z@ \raggedright \normalfont
+%%    \ifnum \c@secnumdepth >\m@ne
+%%      \if@mainmatter
+%%        \huge\bfseries \@chapapp\space \thechapter
+%%        \par\nobreak
+%%        \vskip 20\p@
+%%      \fi
+%%    \fi
+%%    \interlinepenalty\@M
+%%    \Huge \bfseries #1\par\nobreak
+%%    \vskip 40\p@}
   {\parindent \z@ \raggedright \baselineskip \z@ \lineskip \z@ \parskip \z@
     \vbox{
     \vskip -2\p@
@@ -765,19 +795,23 @@
     \else
 \fi
     \vskip 19.3\p@}
-    \def\theequation{\thechapter.\arabic{equation}}}%
-
-
+    \def\theequation{\thechapter.\arabic{equation}}
+    }
 \def\@schapter#1{\if@twocolumn
                    \@topnewpage[\@makeschapterhead{#1}]%
                  \else
                    \@makeschapterhead{#1}%
-                   \addcontentsline{toc}{fm}{#1}
+                                      \addcontentsline{toc}{fm}{#1}
                    \markboth{#1}{#1}
                    \@afterheading
                  \fi}
-                 
 \def\@makeschapterhead#1{%
+%%  \vspace*{50\p@}%
+%%  {\parindent \z@ \raggedright
+%%    \normalfont
+%%    \interlinepenalty\@M
+%%    \Huge \bfseries  #1\par\nobreak
+%%    \vskip 40\p@}
   {\parindent \z@ \raggedright \baselineskip 6\p@ \lineskip \z@ \parskip \z@
     \vbox{
     \vskip 22\p@
@@ -786,71 +820,30 @@
     \FMHeadFont #1\par\vskip-12pt
     \noindent\hbox{\vrule height.5pt width84pt}
     \vskip 41\p@}}%
-  \def\theequation{\thechapter.\arabic{equation}}}
+  \def\theequation{\thechapter.\arabic{equation}}
+  }
+%%\newcommand\section{\@startsection {section}{1}{\z@}%
+%%                                   {-3.5ex \@plus -1ex \@minus -.2ex}%
+%%                                   {2.3ex \@plus.2ex}%
+%%                                   {\normalfont\Large\bfseries}}
+%%\newcommand\subsection{\@startsection{subsection}{2}{\z@}%
+%%                                     {-3.25ex\@plus -1ex \@minus -.2ex}%
+%%                                     {1.5ex \@plus .2ex}%
+%%                                     {\normalfont\large\bfseries}}
+%%\newcommand\subsubsection{\@startsection{subsubsection}{3}{\z@}%
+%%                                     {-3.25ex\@plus -1ex \@minus -.2ex}%
+%%                                     {1.5ex \@plus .2ex}%
+%%                                     {\normalfont\normalsize\bfseries}}
+%%\newcommand\paragraph{\@startsection{paragraph}{4}{\z@}%
+%%                                    {3.25ex \@plus1ex \@minus.2ex}%
+%%                                    {-1em}%
+%%                                    {\normalfont\normalsize\bfseries}}
+%%\newcommand\subparagraph{\@startsection{subparagraph}{5}{\parindent}%
+%%                                       {3.25ex \@plus1ex \@minus .2ex}%
+%%                                       {-1em}%
+%%                                      {\normalfont\normalsize\bfseries}}
 
-%%%\def\@startsection#1#2#3#4#5#6{%
-%%%  \if@noskipsec\leavevmode\fi
-%%%  \par
-%%%  \@tempskipa #4\relax
-%%%  \@afterindenttrue
-%%%  \ifdim \@tempskipa <\z@
-%%%    \@tempskipa -\@tempskipa \@afterindentfalse
-%%%  \fi
-%%%  \if@nobreak
-%%%    \everypar{}%
-%%%  \else
-%%%    \addpenalty\@secpenalty\addvspace\@tempskipa
-%%%  \fi
-%%%  \@ifstar
-%%%    {\@ssect{#1}{#3}{#4}{#5}{#6}}%
-%%%    {\@trplarg{\@sect{#1}{#2}{#3}{#4}{#5}{#6}}}}
-%%%\def\@ssect#1#2#3#4#5#6{%
-%%%  \@tempskipa #4\relax
-%%%  \ifdim \@tempskipa>\z@
-%%%    \begingroup
-%%%      #5{%
-%%%        \@hangfrom{\hskip #2}%
-%%%          \interlinepenalty \@M #6\@@par}%
-%%%    \endgroup
-%%%    \csname #1mark\endcsname{#6}%
-%%%  \else
-%%%    \def\@svsechd{#5{\hskip #2\relax #6}\csname #1mark\endcsname{#6}}%
-%%%  \fi
-%%%  \@xsect{#4}}
-%%%\def\@sect#1#2#3#4#5#6[#7][#8]#9{%
-%%%  \ifnum #2>\c@secnumdepth
-%%%    \let\@svsec\@empty
-%%%  \else
-%%%    \refstepcounter{#1}%
-%%%\protected@edef\@svsec{\@seccntformat{#1}\relax}%
-%%%  \fi
-%%%  \@tempskipa #5\relax
-%%%  \ifdim \@tempskipa>\z@
-%%%    \begingroup
-%%%      #6{%
-%%%\@hangfrom{\hskip #3\relax\@svsec}\interlinepenalty \@M %
-%%%          #9\@@par}%
-%%%    \endgroup
-%%%    \csname #1mark\endcsname{%
-%%%      #8}%
-%%%    \addcontentsline{toc}{#1}{%
-%%%      \ifnum #2>\c@secnumdepth \else
-%%%        \protect\numberline{\csname the#1\endcsname}%
-%%%      \fi
-%%%      #7}%
-%%%  \else
-%%%    \def\@svsechd{%
-%%%      #6{\hskip #3\relax
-%%%      \@svsec #9}%
-%%%      \csname #1mark\endcsname{%
-%%%        #8}%
-%%%      \addcontentsline{toc}{#1}{%
-%%%        \ifnum #2>\c@secnumdepth \else
-%%%          \protect\numberline{\csname the#1\endcsname}%
-%%%        \fi
-%%%        #7}}%
-%%%  \fi
-%%%  \@xsect{#5}}
+
 
 %%Change mydotted also
 \newdimen\secwd
@@ -873,34 +866,32 @@
   \@ifstar{\@ssection}{\@trplarg{\@section}}}
 \def\@ssection#1{%
   \if@ChapterTOCs
-    \myaddcontentsline{\@chaptoc}{chapsection}{\string\makebox[\secnumwidth][l]{}#1}\fi
+    \myaddcontentsline{\@chaptoc}{chapsection}{\protect\ssubnumberline{}#1}\fi
   \@startsection{section}{1}{\z@}{-30\p@}{6\p@}{\sec@rule\nopagebreak\vskip9.5\p@\nopagebreak\SectionHeadFont}*{#1}}
 \def\@section[#1][#2]#3{%
   \if@ChapterTOCs
     \addtocounter{section}{1}%
         \myaddcontentsline{\@chaptoc}{chapsection}{\protect\ssubnumberline{\thesection}#1}%
     \addtocounter{section}{-1}\fi
-  \@startsection{section}{1}{\z@}{-30\p@}{6\p@}{\sec@rule\nopagebreak\vskip9.5\p@\nopagebreak\SectionHeadFont}[#2]{#3}}
+  \@startsection{section}{1}{\z@}{-30\p@}{6\p@}{\sec@rule\nopagebreak\vskip9.5\p@\nopagebreak\SectionHeadFont\ignorespaces\noindent}[#2]{#3}}
 \def\sectionauthor#1{\hfill{\ChapTOCAuthorFont #1}}
 
 \newcommand\subsection{\@ifstar{\@ssubsection}{\@trplarg{\@subsection}}}
 \def\@ssubsection#1{%
   \if@ChapterTOCs
-    \myaddcontentsline{\@chaptoc}{chapsubsection}{\string\makebox[\subsecnumwidth][l]{}#1}\fi
-  \@startsection{subsection}{2}{\z@}{-18\p@}{6\p@}{%
-    \SubsectionHeadFont}*{#1}}
+    \myaddcontentsline{\@chaptoc}{chapsubsection}{\protect\subnumberline{ }#1}\fi
+  \@startsection{subsection}{2}{\z@}{-18\p@}{6\p@}{\SubsectionHeadFont}*{#1}}
 \def\@subsection[#1][#2]#3{%
   \if@ChapterTOCs
     \addtocounter{subsection}{1}%
         \myaddcontentsline{\@chaptoc}{chapsubsection}{\protect\subnumberline{\thesubsection}#1}%
     \addtocounter{subsection}{-1}\fi
-  \@startsection{subsection}{2}{\z@}{-18\p@}{6\p@}{%
-    \SubsectionHeadFont}[#2]{#3}}
+  \@startsection{subsection}{2}{\z@}{-18\p@}{6\p@}{\ignorespaces\noindent\SubsectionHeadFont}[#2]{#3}}
 
 \newcommand\subsubsection{\@ifstar{\@ssubsubsection}{\@trplarg{\@subsubsection}}}
 \def\@ssubsubsection#1{%
   \if@ChapterTOCs
-    \myaddcontentsline{\@chaptoc}{chapsubsubsection}{\string\makebox[\subsecnumwidth][l]{}#1}\fi
+    \myaddcontentsline{\@chaptoc}{chapsubsubsection}{\protect\subsubnumberline{}#1}\fi
   \@startsection{subsubsection}{3}{\z@}{-12\p@}{6\p@}{%
     \SubsubsectionHeadFont}*{#1}}
 \def\@subsubsection[#1][#2]#3{%
@@ -916,6 +907,7 @@
 
 \newcommand\subparagraph{\@startsection{subparagraph}{5}{\parindent}%
 {-12\p@}{6\p@}{\SubParagraphHeadFont}}
+
 
 
 \if@twocolumn
@@ -951,10 +943,11 @@
 \renewcommand\p@enumii{\theenumi}
 \renewcommand\p@enumiii{\theenumi(\theenumii)}
 \renewcommand\p@enumiv{\p@enumiii\theenumiii}
-\newcommand\labelitemi{\textbullet}
-\newcommand\labelitemii{\normalfont\bfseries \textendash}
-\newcommand\labelitemiii{\textasteriskcentered}
-\newcommand\labelitemiv{\textperiodcentered}
+\newcommand\labelitemi  {\labelitemfont \textbullet}
+\newcommand\labelitemii {\labelitemfont \bfseries \textendash}
+\newcommand\labelitemiii{\labelitemfont \textasteriskcentered}
+\newcommand\labelitemiv {\labelitemfont \textperiodcentered}
+\newcommand\labelitemfont{\normalfont}
 \newenvironment{description}
                {\list{}{\labelwidth\z@ \itemindent-\leftmargin
                         \let\makelabel\descriptionlabel}}
@@ -982,7 +975,7 @@
                 \item\relax}
                {\endlist}
 \if@compatibility
-\newenvironment{titlepage}
+  \newenvironment{titlepage}
     {%
       \cleardoublepage
       \if@twocolumn
@@ -996,7 +989,7 @@
     {\if@restonecol\twocolumn \else \newpage \fi
     }
 \else
-\newenvironment{titlepage}
+  \newenvironment{titlepage}
     {%
       \cleardoublepage
       \if@twocolumn
@@ -1059,583 +1052,29 @@
 \newlength\belowcaptionskip
 \setlength\abovecaptionskip{10\p@}
 \setlength\belowcaptionskip{0\p@}
+
+\def\Fig{figure}
 \long\def\@makecaption#1#2{%
   \vskip\abovecaptionskip
-  \sbox\@tempboxa{#1: #2}%
+  \ifx\@captype\Fig
+   \sbox\@tempboxa{{\FigCapFont #1}\par #2}%
   \ifdim \wd\@tempboxa >\hsize
     {\FigCapFont #1}\par #2\par
   \else
-    \global \@minipagefalse
+%    \global \@minipagefalse
 %    \hb@xt@\hsize{\hfil\box\@tempboxa\hfil}%
     {\FigCapFont #1}\par #2\par
   \fi
-  \vskip\belowcaptionskip}
-\DeclareOldFontCommand{\rm}{\normalfont\rmfamily}{\mathrm}
-\DeclareOldFontCommand{\sf}{\normalfont\sffamily}{\mathsf}
-\DeclareOldFontCommand{\tt}{\normalfont\ttfamily}{\mathtt}
-\DeclareOldFontCommand{\bf}{\normalfont\bfseries}{\mathbf}
-\DeclareOldFontCommand{\it}{\normalfont\itshape}{\mathit}
-\DeclareOldFontCommand{\sl}{\normalfont\slshape}{\@nomath\sl}
-\DeclareOldFontCommand{\sc}{\normalfont\scshape}{\@nomath\sc}
-\DeclareRobustCommand*\cal{\@fontswitch\relax\mathcal}
-\DeclareRobustCommand*\mit{\@fontswitch\relax\mathnormal}
-\newcommand\@pnumwidth{1.55em}
-\newcommand\@tocrmarg{2.55em}
-\newcommand\@dotsep{4.5}
-\setcounter{tocdepth}{3}
-
-
-\newcounter{numauthors}
-\newif\if@break
-\newif\if@firstauthor
-\newcommand\tableofcontents{\cleardoublepage\markboth{Contents}{Contents}%
-  \make@cornermarks
-    \gdef\chapterauthor{\@caplusone}%
-  \gdef\endchapterauthors{\end@casplusone}%
-    \if@twocolumn
-      \@restonecoltrue\onecolumn
-    \else
-      \@restonecolfalse
-    \fi
-      {\parindent \z@ \raggedright \baselineskip 6\p@ \lineskip \z@ \parskip \z@
-    \vbox{
-    \vskip 22\p@
-    \unnumchap@rule
-    \vskip 5\p@
-    \FMHeadFont \contentsname\par\vskip-12pt
-    \noindent\hbox{\vrule height.5pt width84pt}
-    \vskip 41\p@}}
-%%%    \chapter*{\contentsname
-%%%        \@mkboth{%
-%%%           \MakeUppercase\contentsname}{\MakeUppercase\contentsname}}%
-           \pagestyle{headings}\thispagestyle{folio}
-             {\let\break\space
-    \let\author\toc@author
-    \reset@authors
-    \let\toc@draw\relax
-    \@starttoc{toc}
-    \toc@draw
-    }
-    \if@restonecol\twocolumn\fi
-    }
-    
-  
-\def\draw@part#1#2{%
-  \addpenalty{-\@highpenalty}%
-  \vskip1em plus\p@
-  \@tempdima1.5em
-  \begingroup
-    \parindent\z@\rightskip\@pnumwidth
-    \parfillskip-\rightskip
-    \bfseries
-    \leavevmode
-    \advance\leftskip\@tempdima
-    \hskip-\leftskip
-    {#1\hfil}\nobreak
-      \if@pdf
-      \else
-        \hfil\nobreak\hb@xt@\@pnumwidth{\hss #2}%
-\fi
-    \par
-    \penalty\@highpenalty\endgroup}
-
-\let\toc@draw\relax
-%
-\def\l@part#1#2{% 
-\toc@draw
- \gdef\toc@draw{\draw@part{\large #1}{\large #2}}}
-
-\def\l@fm#1#2{%
-  \toc@draw
-  \gdef\toc@draw{\draw@fm{#1}{#2}}}
-\def\@pnumwidth{1.8em}
-\def\draw@fm#1#2{%
-  \addpenalty{-\@highpenalty}%
-  \vskip1em plus\p@
-  \@tempdima1.5em
-  \begingroup
-    \parindent\z@\rightskip\@pnumwidth
-    \parfillskip-\rightskip
-    \bfseries
-    \leavevmode
-    \advance\leftskip\@tempdima
-    \hskip-\leftskip
-    {#1\hfil}\nobreak
-      \if@pdf
-      \else
-        \hfil\nobreak\hb@xt@\@pnumwidth{\hss #2}%
-\fi
-    \par
-    \penalty\@highpenalty\endgroup}
-    
-
-
-  \def\l@chapter#1#2{%
-  \toc@draw
-  \gdef\toc@draw{\draw@chapter{#1}{#2}}}
-\def\@pnumwidth{1.8em}
-\def\draw@chapter#1#2{%
-  \addpenalty{-\@highpenalty}%
-  \vskip1em plus\p@
-  \@tempdima1.5em
-  \begingroup
-    \parindent\z@\rightskip\@pnumwidth
-    \parfillskip-\rightskip
-    \bfseries
-    \leavevmode
-    \advance\leftskip\@tempdima
-    \hskip-\leftskip
-    {#1\hfil}\nobreak
-      \if@pdf
-      \else
-        \hfil\nobreak\hb@xt@\@pnumwidth{\hss #2}%
-\fi
-    \par
-    {\it\draw@authors}%
-    \penalty\@highpenalty\endgroup}
-\def\toc@author#1#2{%
-  \if@firstauthor
-    \@firstauthorfalse
   \else
-    \ifx\@authors\@empty
-      \xdef\@authors{\last@author}%
-    \else
-      \@cons{\@authors}{, \last@author}\fi\fi
-  \stepcounter{numauthors}%
-%%%%%%% commented and deleted below the second part to aviod inaccessible error % shashi % September-2008
-%%  \gdef\last@author{#1 {\rm\fontsize{9\p@}{11\p@}\selectfont #2}}
-\gdef\last@author{#1}
-}
-\def\draw@authors{%
-  \let\@t\@authors
-  \ifx\@t\@empty
-    \let\@t\last@author\fi
-  \ifx\@t\@empty\else
-    \hskip\leftskip
-    \ifx\@authors\@empty
-    \else
-      \@authors
-      \ifnum\c@numauthors>2,\fi
-      \if@break\break\fi
-      \ and \fi
-    \last@author\break\fi
-  \reset@authors}
-\def\reset@authors{%
-  \gdef\@authors{}%
-  \gdef\last@author{}%
-  \@firstauthortrue
-  \setcounter{numauthors}{0}}
-\newlength\section@toc@skip
-\section@toc@skip1.5em
-\newlength\SectionTOCWidth
-\SectionTOCWidth2.3em
-\def\l@section#1#2{%
-  \toc@draw
-  \gdef\toc@draw{\draw@section{#1}{#2}}}
-\def\draw@section#1#2{%
-  \@dottedtocline{1}{\section@toc@skip}{\SectionTOCWidth}{#1 }{{
-\tocfont #2}}}
-\newlength\subsection@toc@skip
-\subsection@toc@skip\section@toc@skip
-\advance\subsection@toc@skip\SectionTOCWidth
-\newlength\SubSectionTOCWidth
-\SubSectionTOCWidth3.2em
-\def\l@subsection#1#2{%
-  \toc@draw
-  \gdef\toc@draw{\draw@subsection{#1}{#2}}}
-\def\draw@subsection#1#2{%
-  \@dottedtocline{2}{\subsection@toc@skip}{\SubSectionTOCWidth}{#1}{{
-\tocfont #2}}}
-\newlength\subsubsection@toc@skip
-\subsubsection@toc@skip\subsection@toc@skip
-\advance\subsubsection@toc@skip\SubSectionTOCWidth
-\newlength\SubSubSectionTOCWidth
-\SubSubSectionTOCWidth4.1em
-\def\l@subsubsection#1#2{%
-  \toc@draw
-  \gdef\toc@draw{\draw@subsubsection{#1}{#2}}}
-\def\draw@subsubsection#1#2{%
-  \@dottedtocline{3}{\subsubsection@toc@skip}{\SubSubSectionTOCWidth}{#1}{{
-\tocfont #2}}}
-\newlength\paragraph@toc@skip
-\paragraph@toc@skip\subsubsection@toc@skip
-\advance\paragraph@toc@skip\SubSubSectionTOCWidth
-\newlength\ParagraphTOCWidth
-\ParagraphTOCWidth4.1em
-\def\l@paragraph#1#2{%
-  \toc@draw
-  \gdef\toc@draw{\draw@paragraph{#1}{#2}}}
-\def\draw@paragraph#1#2{%
-  \@dottedtocline{4}{\paragraph@toc@skip}{\ParagraphTOCWidth}{#1}{{
-\tocfont #2}}}
-\newlength\subparagraph@toc@skip
-\subparagraph@toc@skip\paragraph@toc@skip
-\advance\subparagraph@toc@skip\ParagraphTOCWidth
-\def\l@subparagraph#1#2{%
-  \toc@draw
-  \gdef\toc@draw{\draw@subparagraph{#1}{#2}}}
-\def\draw@subparagraph#1#2{%
-  \@dottedtocline{5}{\subparagraph@toc@skip}{6em}{#1}{{
-\tocfont #2}}}
-
-\def\@dottedtocline#1#2#3#4#5{%
-  \ifnum #1>\c@tocdepth
-  \else
-    \vskip \z@ \@plus.2\p@
-    {\leftskip #2\relax\rightskip\@tocrmarg\parfillskip-\rightskip
-      \parindent #2\relax\@afterindenttrue
-      \interlinepenalty\@M
-      \leavevmode
-      \@tempdima #3\relax
-      \advance\leftskip\@tempdima\null\hskip-\leftskip
-      {#4\hfil}\nobreak
-      \if@pdf
-      \else
-        \leaders\hbox{$\m@th\mkern\@dotsep mu\hbox{.}\mkern\@dotsep mu$}\hfill
-        \nobreak
-        \hb@xt@\@pnumwidth{\hfil\normalfont\normalcolor #5}%
-\fi
-      \par}\fi}
-      
-\newcommand\chapterauthors{%
-  \def\break{\string\break\ }%
-  \def\protect##1{\string ##1 }}
-\def\end@cas{}
-\def\end@casplusone{\vskip4pt\@doendpe}
-
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% 
-\def\make@chaptoc{% chapter author 
-  {\parindent\z@
-  \newcommand\FolioBoldFont{}%
-  \let\@b\bullet
-  \def\bullet{\raisebox{2pt}{$\scriptscriptstyle\@b$}}%
-  \let\SubsectionItalicFont\it
-%\ifx\chapter@author\@empty\else
-{\rm\fontsize{10\p@}{10\p@}\bfseries\selectfont
-%\the\c@numauthors
-    \ifnum\c@numauthors=1
-        \chapter@authorone\vskip6\p@
-        {\it\fontsize{10\p@}{10\p@}\selectfont\chapter@affiliationone}\vskip12\p@
-            \fi
-        \ifnum\c@numauthors=2
-                    \chapter@authorone\vskip6\p@
-        {\it\fontsize{10\p@}{10\p@}\selectfont\chapter@affiliationone}\vskip12\p@
-                        \chapter@authortwo\vskip6\p@
-        {\it\fontsize{10\p@}{10\p@}\selectfont\chapter@affiliationtwo}
-                            \fi
-                                \ifnum\c@numauthors=3
-                                    \chapter@authorone\vskip6\p@
-        {\it\fontsize{10\p@}{10\p@}\selectfont\chapter@affiliationone}\vskip12\p@
-                                        \chapter@authortwo\vskip6\p@
-        {\it\fontsize{10\p@}{10\p@}\selectfont\chapter@affiliationtwo}\vskip12\p@
-                                            \chapter@authorthree\vskip6\p@
-        {\it\fontsize{10\p@}{10\p@}\selectfont\chapter@affiliationthree}
-                                                \fi
-                                                    \ifnum\c@numauthors=4
-                                                        \chapter@authorone\vskip6\p@
-        {\it\fontsize{10\p@}{10\p@}\selectfont\chapter@affiliationone}\vskip12\p@
-                                                            \chapter@authortwo\vskip6\p@
-        {\it\fontsize{10\p@}{10\p@}\selectfont\chapter@affiliationtwo}\vskip12\p@
-                                                                \chapter@authorthree\vskip6\p@
-        {\it\fontsize{10\p@}{10\p@}\selectfont\chapter@affiliationthree}\vskip12\p@
-                                                                    \chapter@authorfour\vskip6\p@
-        {\it\fontsize{10\p@}{10\p@}\selectfont\chapter@affiliationfour}
-                                                                        \fi
-}
- \gdef\chapter@authorone{}\gdef\chapter@affiliationone{}%
- \gdef\chapter@authortwo{}\gdef\chapter@affiliationtwo{}%
- \gdef\chapter@authorthree{}\gdef\chapter@affiliationthree{}%
- \gdef\chapter@authorfour{}\gdef\chapter@affiliationfour{}%
-  \vskip 14.6\p@
-{\leftskip\secnumwidth\def\author##1##2{}\vskip14pt\hbox{\leftskip0pt\SubsectionHeadFont CONTENTS}\vskip6pt\par\@input{\thechapter.toc}\par}%
-  }
-\reset@authors}
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-\newif\iffinishedfromone
-\global\finishedfromonefalse
-%
-\newif\iffinishedfromtwo
-\global\finishedfromtwofalse
-%
-\newif\iffinishedfromthree
-\global\finishedfromthreefalse
-%
-\newif\iffinishedfromfour
-\global\finishedfromfourfalse
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-%
-\newcommand\singleauthorchapter{\finishedfromonetrue}
-\newcommand\twoauthorchapter{\finishedfromtwotrue}
-\newcommand\threeauthorchapter{\finishedfromthreetrue}
-\newcommand\fourauthorchapter{\finishedfromfourtrue}
-%
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-\newif\iffinish
-\global\finishfalse
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-\newsavebox\@AUonebox
-\newsavebox\@AUtwobox
-\newsavebox\@AUthreebox
-\newsavebox\@AUfourbox
-%
-\newsavebox\@AUaffonebox
-\newsavebox\@AUafftwobox
-\newsavebox\@AUaffthreebox
-\newsavebox\@AUafffourbox
-%
-\newsavebox\@finalAUboxfromone
-\newsavebox\@finalAUboxfromtwo
-\newsavebox\@finalAUboxfromthree
-\newsavebox\@finalAUboxfromfour
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-
-\def\@ca#1#2{%
-%  \def\chapter@author{#1}%
-%  \def\chapter@affiliation{#2}%
-  \if@filesw%
-    \write\@auxout{%
-\string\@writefile{toc}{\string\author{#1}{}}%
-}%
+  \let\caption\tabletitle
+%  \@tablecaption{#1}{#2}
   \fi
-%%%%%%%%%%%%%%%
+  \vskip\belowcaptionskip}
 
-\ifnum\c@numauthors>4
-    \resetcounter{numauthors}
-\fi 
-\stepcounter{numauthors}
-%%\the\c@numauthors
-\ifnum\c@numauthors=1 % 
-    \sbox\@AUonebox{\CAPlusOneFont#1}
-    \sbox\@AUaffonebox{\vbox{\hsize\textwidth\CAAPlusOneFont\noindent #2\par}}
-    \sbox\@finalAUboxfromone{\copy\@AUonebox}
-    \def\chapter@authorone{\copy\@finalAUboxfromone}
-    \def\chapter@affiliationone{\copy\@AUaffonebox}
-\fi \ifnum\c@numauthors=2
-    \sbox\@AUtwobox{\CAPlusOneFont#1}
-    \sbox\@AUafftwobox{\vbox{\hsize\textwidth\CAAPlusOneFont\noindent #2\par}}
-    \sbox\@finalAUboxfromtwo{\copy\@AUtwobox}
-    \def\chapter@authortwo{\copy\@finalAUboxfromtwo}
-    \def\chapter@affiliationtwo{\copy\@AUafftwobox}
-\fi \ifnum\c@numauthors=3
-    \sbox\@AUthreebox{\CAPlusOneFont#1}
-    \sbox\@AUaffthreebox{\vbox{\hsize\textwidth\CAAPlusOneFont\noindent #2\par}}
-    \sbox\@finalAUboxfromthree{\copy\@AUthreebox}
-    \def\chapter@authorthree{\copy\@finalAUboxfromthree}
-    \def\chapter@affiliationthree{\copy\@AUaffthreebox}
-\fi \ifnum\c@numauthors=4
-    \sbox\@AUfourbox{\CAPlusOneFont#1}
-    \sbox\@AUafffourbox{\vbox{\hsize\textwidth\CAAPlusOneFont\noindent #2\par}}
-    \sbox\@finalAUboxfromfour{\copy\@AUfourbox}
-    \def\chapter@authorfour{\copy\@finalAUboxfromfour}
-    \def\chapter@affiliationfour{\copy\@AUafffourbox}
-\fi}
-
-
-\def\@caplusone{\@ifstar{\@scaplusone}{\@ifnextchar[{\@xcaplusone}{\@xcaplusone[]}}}
-\def\@xcaplusone[#1]#2#3{%
-  \def\@@empty{#1}\ifx\@empty\@@empty\@ca{#2}{#3}\else\@ca{#2}{#1}\fi\@scaplusone{#2}{#3}}
-\def\@scaplusone#1#2{%
-  \ifhmode\vskip-12pt\fi
-%%Shashi Commented
-%%%  \noindent\hskip3pc{\CAPlusOneFont\baselineskip14pt #1\def\@t{#2}\ifx\@t\@empty\else,\fi}\hskip6pt{\CAAPlusOneFont #2}\par
-}
-
-\def\chapterauthoronly#1#2{\@ca{#1}{}\@scaplusone{#1}{#2}}
-\def\myaddcontentsline#1#2#3{%
-  \if@filesw
-    \begingroup
-    \let\label\@gobble\let\index\@gobble\let\glossary\@gobble
-    \def\break{\ }%
-    \def\protect##1{\string ##1 }%
-    \@temptokena{\thepage}%
-    \edef\@tempa{\write#1{\string\chapcontentsline{#2}{\string\raggedright\space #3}{\the\@temptokena}}}\@tempa
-    \if@nobreak\ifvmode\nobreak\fi\fi
-    \endgroup
-  \fi}
-\def\chapcontentsline#1{\csname l@#1\endcsname}
-\def\l@chapsection{\@mydottedtocline{1}{\z@}{6pt}}
-\def\l@chapsubsection{\@mydottedtocline{2}{\secnumwidth}{6pt}}
-\def\l@chapsubsubsection{\@mydottedtocline{3}{\subsecnumwidth}{36pt}}
-\newcount\c@chaptocdepth
-\setcounter{chaptocdepth}{3}
-\def\@mytocline#1#2#3#4#5{%
-  \ifnum #1>\c@chaptocdepth
-  \else
-    \vskip 2pt plus.2\p@
-    \ifnum #1=1\ifnum\c@chaptocdepth>1\addvspace{12pt}\fi\fi
-    {\leftskip #2\relax% \rightskip \@tocrmarg \parfillskip -\rightskip
-      \interlinepenalty\@M
-      \leavevmode
-      \@tempdima #3\relax
-      \rightskip\z@
-      \vbox{\ChapTOCFont #4\nobreak}%
-      \par}\fi}
-\def\@mydottedtocline#1#2#3#4#5{%
-  \ifnum #1>\c@chaptocdepth
-  \else
-\fontsize{10}{12}\selectfont
-{\leftskip #2\relax \rightskip \@tocrmarg \parfillskip -\rightskip
-     % \parindent #2\relax\@afterindenttrue
-      \interlinepenalty\@M
-      \leavevmode
-      \def\@dotsep{1.2}%
-      \@tempdima #3\relax
-      \rightskip\z@
-%      \advance\hsize-\secnumwidth
-%      \hskip-\secnumwidth
-\if@sevenbyten
-\hangindent\secnumwidth\hsize372pt\else\hangindent\secnumwidth\hsize312pt\fi 
-#4
-        \if@pdf
-          \hfill
-        \else
-          \nobreak\leaders\hbox{$\m@th\mkern\@dotsep mu.\mkern\@dotsep mu$}\hfill\nobreak
-          \hbox to24\p@{\hfil #5}\fi
-      \par}\fi}      
-
-\newcommand\listoffigures{%
-    \if@twocolumn
-      \@restonecoltrue\onecolumn
-    \else
-      \@restonecolfalse
-    \fi
-    \chapter*{\listfigurename}%
-      \@mkboth{\MakeUppercase\listfigurename}%
-              {\MakeUppercase\listfigurename}%
-    \@starttoc{lof}%
-    \if@restonecol\twocolumn\fi
-    }
-\newcommand*\l@figure{\@dottedtocline{1}{1.5em}{2.3em}}
-\newcommand\listoftables{%
-    \if@twocolumn
-      \@restonecoltrue\onecolumn
-    \else
-      \@restonecolfalse
-    \fi
-    \chapter*{\listtablename}%
-      \@mkboth{%
-          \MakeUppercase\listtablename}%
-         {\MakeUppercase\listtablename}%
-    \@starttoc{lot}%
-    \if@restonecol\twocolumn\fi
-    }
-\let\l@table\l@figure
-\newdimen\bibindent
-\setlength\bibindent{1.5em}
-\newenvironment{thebibliography}[1]
-     {\chapter*{\bibname}%
-      \@mkboth{\MakeUppercase\bibname}{\MakeUppercase\bibname}%
-%       \addcontentsline{toc}{chapter}{\bibname}
-      \list{\@biblabel{\@arabic\c@enumiv}}%
-           {\settowidth\labelwidth{\@biblabel{#1}}%
-            \leftmargin\labelwidth
-            \advance\leftmargin\labelsep
-            \@openbib@code
-            \usecounter{enumiv}%
-            \let\p@enumiv\@empty
-            \renewcommand\theenumiv{\@arabic\c@enumiv}}%
-      \sloppy
-      \clubpenalty4000
-      \@clubpenalty \clubpenalty
-      \widowpenalty4000%
-      \sfcode`\.\@m}
-     {\def\@noitemerr
-       {\@latex@warning{Empty `thebibliography' environment}}%
-      \endlist}
-\newcommand\newblock{\hskip .11em\@plus.33em\@minus.07em}
-\let\@openbib@code\@empty
-\newenvironment{theindex}
-               {\cleardoublepage\if@twocolumn
-                  \@restonecolfalse
-                \else
-                  \@restonecoltrue
-                \fi
-                \twocolumn[\@makeschapterhead{\indexname}]%
-                \@mkboth{\MakeUppercase\indexname}%
-                        {\MakeUppercase\indexname}%
-                        \pagestyle{headings}
-                        \addcontentsline{toc}{chapter}{\indexname}
-                \thispagestyle{folio}\parindent\z@\markboth{Index}{Index}
-                \parskip\z@ \@plus .3\p@\relax\raggedright
-                \columnseprule \z@
-                \columnsep 35\p@
-                \let\item\@idxitem}
-               {\if@restonecol\onecolumn\else\clearpage\fi}
-\newcommand\@idxitem{\par\hangindent 40\p@}
-\newcommand\subitem{\@idxitem \hspace*{20\p@}}
-\newcommand\subsubitem{\@idxitem \hspace*{30\p@}}
-\newcommand\indexspace{\par \vskip 10\p@ \@plus5\p@ \@minus3\p@\relax}
-\renewcommand\footnoterule{%
-  \kern-3\p@
-  \hrule\@width.4\columnwidth
-  \kern2.6\p@}
-\@addtoreset{footnote}{chapter}
-\newcommand\@makefntext[1]{%
-    \parindent 1em%
-    \noindent
-    \hb@xt@1.8em{\hss\@makefnmark}#1}
-\newcommand\contentsname{Contents}
-\newcommand\listfigurename{List of Figures}
-\newcommand\listtablename{List of Tables}
-\newcommand\bibname{Bibliography}
-\newcommand\indexname{Index}
-\newcommand\figurename{FIGURE}
-\newcommand\tablename{TABLE}
-\newcommand\partname{Part}
-\newcommand\chaptername{Chapter}
-\newcommand\appendixname{Appendix}
-\def\today{\ifcase\month\or
-  January\or February\or March\or April\or May\or June\or
-  July\or August\or September\or October\or November\or December\fi
-  \space\number\day, \number\year}
-\setlength\columnsep{10\p@}
-\setlength\columnseprule{0\p@}
-\pagestyle{headings}
-\pagenumbering{arabic}
-\if@twoside
-\else
-  \raggedbottom
-\fi
-\if@twocolumn
-  \twocolumn
-  \sloppy
-  \flushbottom
-\else
-  \onecolumn
-\fi
-\newcommand\unnumcrcrule{\hbox to\textwidth{\rlap{\rule[-3.5\p@]{84\p@}{4\p@}}}}
-\newcommand\unnumchap@rule{\unnumcrcrule}
-\newcommand\crcrule{\hbox to\textwidth{\rlap{\rule[-3.5\p@]{84\p@}{4\p@}}\rule{\textwidth}{.5\p@}}}
-\newcommand\chap@rule{\crcrule}
-\newcommand\sec@rule{\crcrule}
-\def\@affiliate[#1]{\gdef\@affiliation{#1}}
-\def\@affiliation{}
-
-\def\def@theequation{%
-  \if@numberinsequence
-    \def\theequation{%
-\if@numbysec\thesection\else\thechapter\fi.%
-\@arabic\c@shared}%
-  \else
-    \def\theequation{%
-\if@numbysec\thesection\else\thechapter\fi.%
-\@arabic\c@equation}\fi}
-
-\def\affiliation#1{{\AffiliationFont\noindent #1\vskip 36bp}}
-\newbox\tempbox
-
-\newdimen\nomenwidth
-
-\newenvironment{symbollist}[1]{%
-\addvspace{12pt}
-			\setbox\tempbox\hbox{#1\hskip1em}%
-   \global\nomenwidth\wd\tempbox
-   %\section*{Sumbol Description}
-\noindent{\SectionHeadFont Symbol Description}\vskip6pt
-\begin{multicols}{2}}{%
-		\end{multicols}\par\addvspace{12pt}}
-\def\symbolentry#1#2{\par\noindent\@hangfrom{\hbox to \nomenwidth{#1\hss}}#2\par}
-
+%%\def\@tablecaption#1#2{%
+%%{\FigCapFont#1}\hskip6.5pt{#2}\par\vskip-6pt
+%%\noindent\vbox{\hrule width\textwidth height.5pt}
+%%}  
 
 \tabcolsep 5pt
 \arrayrulewidth .5pt
@@ -1754,33 +1193,884 @@
   \vskip 0pt plus 12pt
   \gdef\@Tabletitle{}}
 
-\def\tch#1{\TableColHeadFont #1\llstrut\hfill}
-\def\tsh#1{\TableSubheadFont #1\hfill}
-\newcommand\llstrut{\rule[-6pt]{0pt}{14pt}}
-\newcommand\flstrut{\rule{0pt}{10pt}}
-\newcommand\tabletitlestrut{\rule{0pt}{20pt}}
 
-\def\Boxhead#1{\par\addvspace{3pt plus2pt}\noindent{\centering\bfseries#1\par}\vskip3pt}
+  
+  
+\DeclareOldFontCommand{\rm}{\normalfont\rmfamily}{\mathrm}
+\DeclareOldFontCommand{\sf}{\normalfont\sffamily}{\mathsf}
+\DeclareOldFontCommand{\tt}{\normalfont\ttfamily}{\mathtt}
+\DeclareOldFontCommand{\bf}{\normalfont\bfseries}{\mathbf}
+\DeclareOldFontCommand{\it}{\normalfont\itshape}{\mathit}
+\DeclareOldFontCommand{\sl}{\normalfont\slshape}{\@nomath\sl}
+\DeclareOldFontCommand{\sc}{\normalfont\scshape}{\@nomath\sc}
+\DeclareRobustCommand*\cal{\@fontswitch\relax\mathcal}
+\DeclareRobustCommand*\mit{\@fontswitch\relax\mathnormal}
+\newcommand\@pnumwidth{1.55em}
+\newcommand\@tocrmarg{2.55em}
+\newcommand\@dotsep{4.5}
+\setcounter{tocdepth}{3}
 
 
-\newbox\tempbox%
-\newdimen\tempdimen%
+\newcounter{numauthors}
+\newif\if@break
+\newif\if@firstauthor
+\newcommand\tableofcontents{\cleardoublepage\markboth{Contents}{Contents}%%
+    \gdef\chapterauthor{\@caplusone}%
+  \gdef\endchapterauthors{\end@casplusone}%
+    \if@twocolumn
+      \@restonecoltrue\onecolumn
+    \else
+      \@restonecolfalse
+    \fi
+      {\parindent \z@ \raggedright \baselineskip 6\p@ \lineskip \z@ \parskip \z@
+    \vbox{
+    \vskip 22\p@
+    \unnumchap@rule
+    \vskip 5\p@
+    \FMHeadFont \contentsname\par\vskip-12pt
+    \noindent\hbox{\vrule height.5pt width84pt}
+    \vskip 41\p@}}
+%%    \chapter*{\contentsname
+%%        \@mkboth{%\MakeUppercase
+%%           \contentsname}{\contentsname}}%\MakeUppercase
+           \pagestyle{headings}\thispagestyle{folio}
+             {\let\break\space
+    \let\author\toc@author
+    \reset@authors
+    \let\toc@draw\relax
+    \@starttoc{toc}
+    \toc@draw
+    }
+    \if@restonecol\twocolumn\fi
+    }
+
+%%\newcounter{numauthors}
+%%\newif\if@break
+%%\newif\if@firstauthor
+%%\newcommand\tableofcontents{\cleardoublepage\markboth{Contents}{Contents}%
+%%  \make@cornermarks
+%%    \gdef\chapterauthor{\@caplusone}%
+%%  \gdef\endchapterauthors{\end@casplusone}%
+%%    \if@twocolumn
+%%      \@restonecoltrue\onecolumn
+%%    \else
+%%      \@restonecolfalse
+%%    \fi
+%%      {\parindent \z@ \raggedright \baselineskip 6\p@ \lineskip \z@ \parskip \z@
+%%    \vbox{
+%%    \vskip 22\p@
+%%    \unnumchap@rule
+%%    \vskip 5\p@
+%%    \FMHeadFont \contentsname\par\vskip-12pt
+%%    \noindent\hbox{\vrule height.5pt width84pt}
+%%    \vskip 41\p@}}
+%%%%%    \chapter*{\contentsname
+%%%%%        \@mkboth{%
+%%%%%           \MakeUppercase\contentsname}{\MakeUppercase\contentsname}}%
+%%           \pagestyle{headings}\thispagestyle{folio}
+%%             {\let\break\space
+%%    \let\author\toc@author
+%%    \reset@authors
+%%    \let\toc@draw\relax
+%%    \@starttoc{toc}
+%%    \toc@draw
+%%    }
+%%    \if@restonecol\twocolumn\fi
+%%    }
+
+
+
+\newcommand*\l@part[2]{%
+  \ifnum \c@tocdepth >-2\relax
+    \addpenalty{-\@highpenalty}%
+    \addvspace{2.25em \@plus\p@}%
+    \setlength\@tempdima{3em}%
+    \begingroup
+      \parindent \z@ \rightskip \@pnumwidth
+      \parfillskip -\@pnumwidth
+      {\leavevmode
+       \large \bfseries #1\hfil
+       \hb@xt@\@pnumwidth{\hss #2%
+                          \kern-\p@\kern\p@}}\par
+       \nobreak
+         \global\@nobreaktrue
+         \everypar{\global\@nobreakfalse\everypar{}}%
+    \endgroup
+  \fi}
+
+\newcommand*\l@fm[2]{%
+  \ifnum \c@tocdepth >\m@ne
+    \addpenalty{-\@highpenalty}%
+    \vskip 1.0em \@plus\p@
+    \setlength\@tempdima{1.5em}%
+    \begingroup
+      \parindent \z@ \rightskip \@pnumwidth
+      \parfillskip -\@pnumwidth
+      \leavevmode \bfseries
+      \advance\leftskip\@tempdima
+      \hskip -\leftskip
+      #1\nobreak\hfil
+      \nobreak\hb@xt@\@pnumwidth{\hss #2%
+                                 \kern-\p@\kern\p@}\par
+      \penalty\@highpenalty
+    \endgroup
+  \fi}
+  
+\newcommand*\l@chapter[2]{%
+  \ifnum \c@tocdepth >\m@ne
+    \addpenalty{-\@highpenalty}%
+    \vskip 1.0em \@plus\p@
+    \setlength\@tempdima{1.5em}%
+    \begingroup
+      \parindent \z@ \rightskip \@pnumwidth
+      \parfillskip -\@pnumwidth
+      \leavevmode \bfseries
+      \advance\leftskip\@tempdima
+      \hskip -\leftskip
+      #1\nobreak\hfil
+      \nobreak\hb@xt@\@pnumwidth{\hss #2%
+                                 \kern-\p@\kern\p@}\par
+\if@ChapterTOCs {\it\draw@authors}\fi%
+      \penalty\@highpenalty
+    \endgroup
+  \fi}
+
+\def\toc@author#1#2{%
+  \if@firstauthor
+    \@firstauthorfalse
+  \else
+    \ifx\@authors\@empty
+      \xdef\@authors{\last@author}%
+    \else
+      \@cons{\@authors}{, \last@author}\fi\fi
+  \stepcounter{numauthors}%
+%%%%%%% commented and deleted below the second part to aviod inaccessible error % shashi % September-2008
+%%  \gdef\last@author{#1 {\rm\fontsize{9\p@}{11\p@}\selectfont #2}}
+\gdef\last@author{#1}
+}
+\def\draw@authors{%
+  \let\@t\@authors
+  \ifx\@t\@empty
+    \let\@t\last@author\fi
+  \ifx\@t\@empty\else
+    \hskip\leftskip
+    \ifx\@authors\@empty
+    \else
+      \@authors
+      \ifnum\c@numauthors>2,\fi
+      \if@break\break\fi
+      \ and \fi
+    \last@author\break\fi
+  \reset@authors}
+\def\reset@authors{%
+  \gdef\@authors{}%
+  \gdef\last@author{}%
+  \@firstauthortrue
+  \setcounter{numauthors}{0}}
+
+
+\newcommand*\l@section{\@dottedtocline{1}{1.5em}{2.3em}}
+\newcommand*\l@subsection{\@dottedtocline{2}{3.8em}{3.2em}}
+\newcommand*\l@subsubsection{\@dottedtocline{3}{7.0em}{4.1em}}
+\newcommand*\l@paragraph{\@dottedtocline{4}{10em}{5em}}
+\newcommand*\l@subparagraph{\@dottedtocline{5}{12em}{6em}}
+
+\def\@dottedtocline#1#2#3#4#5{%
+  \ifnum #1>\c@tocdepth
+  \else
+    \vskip \z@ \@plus.2\p@
+    {\leftskip #2\relax\rightskip\@tocrmarg\parfillskip-\rightskip
+      \parindent #2\relax\@afterindenttrue
+      \interlinepenalty\@M
+      \leavevmode
+      \@tempdima #3\relax
+      \advance\leftskip\@tempdima\null\hskip-\leftskip
+      {#4\hfil}\nobreak
+      \if@pdf
+      \else
+        \leaders\hbox{$\m@th\mkern\@dotsep mu\hbox{.}\mkern\@dotsep mu$}\hfill
+        \nobreak
+        \hb@xt@\@pnumwidth{\hfil\normalfont\normalcolor #5}%
+\fi
+      \par}\fi}
+      
+      
+      \newcommand\chapterauthors{%
+  \def\break{\string\break\ }%
+  \def\protect##1{\string ##1 }}
+\def\end@cas{}
+\def\end@casplusone{\vskip4pt\@doendpe}
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% 
+\def\make@chaptoc{% chapter author % 
+  {\parindent\z@
+  \def\FolioBoldFont{}%
+  \let\@b\bullet
+  \def\bullet{\raisebox{2pt}{$\scriptscriptstyle\@b$}}%
+  \let\SubsectionItalicFont\it
+%\ifx\chapter@author\@empty\else
+{\rm\fontsize{10\p@}{10\p@}\bfseries\selectfont
+%\the\c@numauthors
+    \ifnum\c@numauthors=1
+        \chapter@authorone\vskip6\p@
+        {\it\fontsize{10\p@}{10\p@}\selectfont\chapter@affiliationone}\vskip12\p@
+            \fi
+        \ifnum\c@numauthors=2
+                    \chapter@authorone\vskip6\p@
+        {\it\fontsize{10\p@}{10\p@}\selectfont\chapter@affiliationone}\vskip12\p@
+                        \chapter@authortwo\vskip6\p@
+        {\it\fontsize{10\p@}{10\p@}\selectfont\chapter@affiliationtwo}
+                            \fi
+                                \ifnum\c@numauthors=3
+                                    \chapter@authorone\vskip6\p@
+        {\it\fontsize{10\p@}{10\p@}\selectfont\chapter@affiliationone}\vskip12\p@
+                                        \chapter@authortwo\vskip6\p@
+        {\it\fontsize{10\p@}{10\p@}\selectfont\chapter@affiliationtwo}\vskip12\p@
+                                            \chapter@authorthree\vskip6\p@
+        {\it\fontsize{10\p@}{10\p@}\selectfont\chapter@affiliationthree}
+                                                \fi
+                                                    \ifnum\c@numauthors=4
+                                                        \chapter@authorone\vskip6\p@
+        {\it\fontsize{10\p@}{10\p@}\selectfont\chapter@affiliationone}\vskip12\p@
+                                                            \chapter@authortwo\vskip6\p@
+        {\it\fontsize{10\p@}{10\p@}\selectfont\chapter@affiliationtwo}\vskip12\p@
+                                                                \chapter@authorthree\vskip6\p@
+        {\it\fontsize{10\p@}{10\p@}\selectfont\chapter@affiliationthree}\vskip12\p@
+                                                                    \chapter@authorfour\vskip6\p@
+        {\it\fontsize{10\p@}{10\p@}\selectfont\chapter@affiliationfour}
+                                                                        \fi
+                                                    \ifnum\c@numauthors=5
+                                                        \chapter@authorone\vskip6\p@
+        {\it\fontsize{10\p@}{10\p@}\selectfont\chapter@affiliationone}\vskip12\p@
+                                                            \chapter@authortwo\vskip6\p@
+        {\it\fontsize{10\p@}{10\p@}\selectfont\chapter@affiliationtwo}\vskip12\p@
+                                                                \chapter@authorthree\vskip6\p@
+        {\it\fontsize{10\p@}{10\p@}\selectfont\chapter@affiliationthree}\vskip12\p@
+                                                                    \chapter@authorfour\vskip6\p@
+        {\it\fontsize{10\p@}{10\p@}\selectfont\chapter@affiliationfour}\vskip12\p@
+                                                                            \chapter@authorfive\vskip6\p@
+        {\it\fontsize{10\p@}{10\p@}\selectfont\chapter@affiliationfive}
+                                                                        \fi                                                                        
+                                                    \ifnum\c@numauthors=6
+                                                        \chapter@authorone\vskip6\p@
+        {\it\fontsize{10\p@}{10\p@}\selectfont\chapter@affiliationone}\vskip12\p@
+                                                            \chapter@authortwo\vskip6\p@
+        {\it\fontsize{10\p@}{10\p@}\selectfont\chapter@affiliationtwo}\vskip12\p@
+                                                                \chapter@authorthree\vskip6\p@
+        {\it\fontsize{10\p@}{10\p@}\selectfont\chapter@affiliationthree}\vskip12\p@
+                                                                    \chapter@authorfour\vskip6\p@
+        {\it\fontsize{10\p@}{10\p@}\selectfont\chapter@affiliationfour}\vskip12\p@
+                                                                            \chapter@authorfive\vskip6\p@
+        {\it\fontsize{10\p@}{10\p@}\selectfont\chapter@affiliationfive}\vskip12\p@
+                                                                                    \chapter@authorsix\vskip6\p@
+        {\it\fontsize{10\p@}{10\p@}\selectfont\chapter@affiliationsix}
+                                                                        \fi                                                                                                                                                
+                                                    \ifnum\c@numauthors=7
+                                                        \chapter@authorone\vskip6\p@
+        {\it\fontsize{10\p@}{10\p@}\selectfont\chapter@affiliationone}\vskip12\p@
+                                                            \chapter@authortwo\vskip6\p@
+        {\it\fontsize{10\p@}{10\p@}\selectfont\chapter@affiliationtwo}\vskip12\p@
+                                                                \chapter@authorthree\vskip6\p@
+        {\it\fontsize{10\p@}{10\p@}\selectfont\chapter@affiliationthree}\vskip12\p@
+                                                                    \chapter@authorfour\vskip6\p@
+        {\it\fontsize{10\p@}{10\p@}\selectfont\chapter@affiliationfour}\vskip12\p@
+                                                                      \chapter@authorfive\vskip6\p@
+        {\it\fontsize{10\p@}{10\p@}\selectfont\chapter@affiliationfive}\vskip12\p@
+                                                                       \chapter@authorsix\vskip6\p@
+        {\it\fontsize{10\p@}{10\p@}\selectfont\chapter@affiliationsix}\vskip12\p@
+                                                                               \chapter@authorseven\vskip6\p@
+        {\it\fontsize{10\p@}{10\p@}\selectfont\chapter@affiliationseven}
+                                                                        \fi                                                                                                                                                
+                                                    \ifnum\c@numauthors=8
+                                                        \chapter@authorone\vskip6\p@
+        {\it\fontsize{10\p@}{10\p@}\selectfont\chapter@affiliationone}\vskip12\p@
+                                                            \chapter@authortwo\vskip6\p@
+        {\it\fontsize{10\p@}{10\p@}\selectfont\chapter@affiliationtwo}\vskip12\p@
+                                                                \chapter@authorthree\vskip6\p@
+        {\it\fontsize{10\p@}{10\p@}\selectfont\chapter@affiliationthree}\vskip12\p@
+                                                                    \chapter@authorfour\vskip6\p@
+        {\it\fontsize{10\p@}{10\p@}\selectfont\chapter@affiliationfour}\vskip12\p@
+                                                                      \chapter@authorfive\vskip6\p@
+        {\it\fontsize{10\p@}{10\p@}\selectfont\chapter@affiliationfive}\vskip12\p@
+                                                                       \chapter@authorsix\vskip6\p@
+        {\it\fontsize{10\p@}{10\p@}\selectfont\chapter@affiliationsix}\vskip12\p@
+                                                                       \chapter@authorseven\vskip6\p@
+        {\it\fontsize{10\p@}{10\p@}\selectfont\chapter@affiliationseven}\vskip12\p@
+                                                                        \chapter@authoreight\vskip6\p@
+        {\it\fontsize{10\p@}{10\p@}\selectfont\chapter@affiliationeight}
+                                                                        \fi                                                                                                                                                
+                                                    \ifnum\c@numauthors=9
+                                                        \chapter@authorone\vskip6\p@
+        {\it\fontsize{10\p@}{10\p@}\selectfont\chapter@affiliationone}\vskip12\p@
+                                                            \chapter@authortwo\vskip6\p@
+        {\it\fontsize{10\p@}{10\p@}\selectfont\chapter@affiliationtwo}\vskip12\p@
+                                                                \chapter@authorthree\vskip6\p@
+        {\it\fontsize{10\p@}{10\p@}\selectfont\chapter@affiliationthree}\vskip12\p@
+                                                                    \chapter@authorfour\vskip6\p@
+        {\it\fontsize{10\p@}{10\p@}\selectfont\chapter@affiliationfour}\vskip12\p@
+                                                                      \chapter@authorfive\vskip6\p@
+        {\it\fontsize{10\p@}{10\p@}\selectfont\chapter@affiliationfive}\vskip12\p@
+                                                                       \chapter@authorsix\vskip6\p@
+        {\it\fontsize{10\p@}{10\p@}\selectfont\chapter@affiliationsix}\vskip12\p@
+                                                                       \chapter@authorseven\vskip6\p@
+        {\it\fontsize{10\p@}{10\p@}\selectfont\chapter@affiliationseven}\vskip12\p@
+                                                                        \chapter@authoreight\vskip6\p@
+        {\it\fontsize{10\p@}{10\p@}\selectfont\chapter@affiliationeight}\vskip12\p@
+                                                                        \chapter@authornine\vskip6\p@
+        {\it\fontsize{10\p@}{10\p@}\selectfont\chapter@affiliationnine}
+                                                                        \fi                                                                                                                                                
+                                                    \ifnum\c@numauthors=10
+                                                        \chapter@authorone\vskip6\p@
+        {\it\fontsize{10\p@}{10\p@}\selectfont\chapter@affiliationone}\vskip12\p@
+                                                            \chapter@authortwo\vskip6\p@
+        {\it\fontsize{10\p@}{10\p@}\selectfont\chapter@affiliationtwo}\vskip12\p@
+                                                                \chapter@authorthree\vskip6\p@
+        {\it\fontsize{10\p@}{10\p@}\selectfont\chapter@affiliationthree}\vskip12\p@
+                                                                    \chapter@authorfour\vskip6\p@
+        {\it\fontsize{10\p@}{10\p@}\selectfont\chapter@affiliationfour}\vskip12\p@
+                                                                      \chapter@authorfive\vskip6\p@
+        {\it\fontsize{10\p@}{10\p@}\selectfont\chapter@affiliationfive}\vskip12\p@
+                                                                       \chapter@authorsix\vskip6\p@
+        {\it\fontsize{10\p@}{10\p@}\selectfont\chapter@affiliationsix}\vskip12\p@
+                                                                       \chapter@authorseven\vskip6\p@
+        {\it\fontsize{10\p@}{10\p@}\selectfont\chapter@affiliationseven}\vskip12\p@
+                                                                        \chapter@authoreight\vskip6\p@
+        {\it\fontsize{10\p@}{10\p@}\selectfont\chapter@affiliationeight}\vskip12\p@
+                                                                        \chapter@authornine\vskip6\p@
+        {\it\fontsize{10\p@}{10\p@}\selectfont\chapter@affiliationnine}\vskip12\p@        
+                                                                        \chapter@authorten\vskip6\p@
+        {\it\fontsize{10\p@}{10\p@}\selectfont\chapter@affiliationten}        
+                                                                        \fi                                                                                                                                                
+                                                    \ifnum\c@numauthors=11
+                                                        \chapter@authorone\vskip6\p@
+        {\it\fontsize{10\p@}{10\p@}\selectfont\chapter@affiliationone}\vskip12\p@
+                                                            \chapter@authortwo\vskip6\p@
+        {\it\fontsize{10\p@}{10\p@}\selectfont\chapter@affiliationtwo}\vskip12\p@
+                                                                \chapter@authorthree\vskip6\p@
+        {\it\fontsize{10\p@}{10\p@}\selectfont\chapter@affiliationthree}\vskip12\p@
+                                                                    \chapter@authorfour\vskip6\p@
+        {\it\fontsize{10\p@}{10\p@}\selectfont\chapter@affiliationfour}\vskip12\p@
+                                                                      \chapter@authorfive\vskip6\p@
+        {\it\fontsize{10\p@}{10\p@}\selectfont\chapter@affiliationfive}\vskip12\p@
+                                                                       \chapter@authorsix\vskip6\p@
+        {\it\fontsize{10\p@}{10\p@}\selectfont\chapter@affiliationsix}\vskip12\p@
+                                                                       \chapter@authorseven\vskip6\p@
+        {\it\fontsize{10\p@}{10\p@}\selectfont\chapter@affiliationseven}\vskip12\p@
+                                                                        \chapter@authoreight\vskip6\p@
+        {\it\fontsize{10\p@}{10\p@}\selectfont\chapter@affiliationeight}\vskip12\p@
+                                                                        \chapter@authornine\vskip6\p@
+        {\it\fontsize{10\p@}{10\p@}\selectfont\chapter@affiliationnine}\vskip12\p@        
+                                                                        \chapter@authorten\vskip6\p@
+        {\it\fontsize{10\p@}{10\p@}\selectfont\chapter@affiliationten}\vskip12\p@        
+                                                                        \chapter@authoreleven\vskip6\p@
+        {\it\fontsize{10\p@}{10\p@}\selectfont\chapter@affiliationeleven}
+                                                                        \fi                                                                                                                                                
+                                                    \ifnum\c@numauthors=12
+                                                        \chapter@authorone\vskip6\p@
+        {\it\fontsize{10\p@}{10\p@}\selectfont\chapter@affiliationone}\vskip12\p@
+                                                            \chapter@authortwo\vskip6\p@
+        {\it\fontsize{10\p@}{10\p@}\selectfont\chapter@affiliationtwo}\vskip12\p@
+                                                                \chapter@authorthree\vskip6\p@
+        {\it\fontsize{10\p@}{10\p@}\selectfont\chapter@affiliationthree}\vskip12\p@
+                                                                    \chapter@authorfour\vskip6\p@
+        {\it\fontsize{10\p@}{10\p@}\selectfont\chapter@affiliationfour}\vskip12\p@
+                                                                      \chapter@authorfive\vskip6\p@
+        {\it\fontsize{10\p@}{10\p@}\selectfont\chapter@affiliationfive}\vskip12\p@
+                                                                       \chapter@authorsix\vskip6\p@
+        {\it\fontsize{10\p@}{10\p@}\selectfont\chapter@affiliationsix}\vskip12\p@
+                                                                       \chapter@authorseven\vskip6\p@
+        {\it\fontsize{10\p@}{10\p@}\selectfont\chapter@affiliationseven}\vskip12\p@
+                                                                        \chapter@authoreight\vskip6\p@
+        {\it\fontsize{10\p@}{10\p@}\selectfont\chapter@affiliationeight}\vskip12\p@
+                                                                        \chapter@authornine\vskip6\p@
+        {\it\fontsize{10\p@}{10\p@}\selectfont\chapter@affiliationnine}\vskip12\p@        
+                                                                        \chapter@authorten\vskip6\p@
+        {\it\fontsize{10\p@}{10\p@}\selectfont\chapter@affiliationten}\vskip12\p@        
+                                                                        \chapter@authoreleven\vskip6\p@
+        {\it\fontsize{10\p@}{10\p@}\selectfont\chapter@affiliationeleven}\vskip12\p@        
+                                                                        \chapter@authortwelve\vskip6\p@
+        {\it\fontsize{10\p@}{10\p@}\selectfont\chapter@affiliationtwelve}
+                                                                        \fi                                                                                                                                                
+                                                    \ifnum\c@numauthors=13
+                                                        \chapter@authorone\vskip6\p@
+        {\it\fontsize{10\p@}{10\p@}\selectfont\chapter@affiliationone}\vskip12\p@
+                                                            \chapter@authortwo\vskip6\p@
+        {\it\fontsize{10\p@}{10\p@}\selectfont\chapter@affiliationtwo}\vskip12\p@
+                                                                \chapter@authorthree\vskip6\p@
+        {\it\fontsize{10\p@}{10\p@}\selectfont\chapter@affiliationthree}\vskip12\p@
+                                                                    \chapter@authorfour\vskip6\p@
+        {\it\fontsize{10\p@}{10\p@}\selectfont\chapter@affiliationfour}\vskip12\p@
+                                                                      \chapter@authorfive\vskip6\p@
+        {\it\fontsize{10\p@}{10\p@}\selectfont\chapter@affiliationfive}\vskip12\p@
+                                                                       \chapter@authorsix\vskip6\p@
+        {\it\fontsize{10\p@}{10\p@}\selectfont\chapter@affiliationsix}\vskip12\p@
+                                                                       \chapter@authorseven\vskip6\p@
+        {\it\fontsize{10\p@}{10\p@}\selectfont\chapter@affiliationseven}\vskip12\p@
+                                                                        \chapter@authoreight\vskip6\p@
+        {\it\fontsize{10\p@}{10\p@}\selectfont\chapter@affiliationeight}\vskip12\p@
+                                                                        \chapter@authornine\vskip6\p@
+        {\it\fontsize{10\p@}{10\p@}\selectfont\chapter@affiliationnine}\vskip12\p@        
+                                                                        \chapter@authorten\vskip6\p@
+        {\it\fontsize{10\p@}{10\p@}\selectfont\chapter@affiliationten}\vskip12\p@        
+                                                                        \chapter@authoreleven\vskip6\p@
+        {\it\fontsize{10\p@}{10\p@}\selectfont\chapter@affiliationeleven}\vskip12\p@        
+                                                                        \chapter@authortwelve\vskip6\p@
+        {\it\fontsize{10\p@}{10\p@}\selectfont\chapter@affiliationtwelve}\vskip12\p@        
+                                                                        \chapter@authorthirteen\vskip6\p@
+        {\it\fontsize{10\p@}{10\p@}\selectfont\chapter@affiliationthirteen}                                                                                \fi                                                                                                                                                
+                                                    \ifnum\c@numauthors=14
+                                                        \chapter@authorone\vskip6\p@
+        {\it\fontsize{10\p@}{10\p@}\selectfont\chapter@affiliationone}\vskip12\p@
+                                                            \chapter@authortwo\vskip6\p@
+        {\it\fontsize{10\p@}{10\p@}\selectfont\chapter@affiliationtwo}\vskip12\p@
+                                                                \chapter@authorthree\vskip6\p@
+        {\it\fontsize{10\p@}{10\p@}\selectfont\chapter@affiliationthree}\vskip12\p@
+                                                                    \chapter@authorfour\vskip6\p@
+        {\it\fontsize{10\p@}{10\p@}\selectfont\chapter@affiliationfour}\vskip12\p@
+                                                                      \chapter@authorfive\vskip6\p@
+        {\it\fontsize{10\p@}{10\p@}\selectfont\chapter@affiliationfive}\vskip12\p@
+                                                                       \chapter@authorsix\vskip6\p@
+        {\it\fontsize{10\p@}{10\p@}\selectfont\chapter@affiliationsix}\vskip12\p@
+                                                                       \chapter@authorseven\vskip6\p@
+        {\it\fontsize{10\p@}{10\p@}\selectfont\chapter@affiliationseven}\vskip12\p@
+                                                                        \chapter@authoreight\vskip6\p@
+        {\it\fontsize{10\p@}{10\p@}\selectfont\chapter@affiliationeight}\vskip12\p@
+                                                                        \chapter@authornine\vskip6\p@
+        {\it\fontsize{10\p@}{10\p@}\selectfont\chapter@affiliationnine}\vskip12\p@        
+                                                                        \chapter@authorten\vskip6\p@
+        {\it\fontsize{10\p@}{10\p@}\selectfont\chapter@affiliationten}\vskip12\p@        
+                                                                        \chapter@authoreleven\vskip6\p@
+        {\it\fontsize{10\p@}{10\p@}\selectfont\chapter@affiliationeleven}\vskip12\p@        
+                                                                        \chapter@authortwelve\vskip6\p@
+        {\it\fontsize{10\p@}{10\p@}\selectfont\chapter@affiliationtwelve}\vskip12\p@        
+                                                                        \chapter@authorthirteen\vskip6\p@
+        {\it\fontsize{10\p@}{10\p@}\selectfont\chapter@affiliationthirteen}\vskip12\p@                                                                                                                                                                                              							\chapter@authorfourteen\vskip6\p@
+        {\it\fontsize{10\p@}{10\p@}\selectfont\chapter@affiliationfourteen}
+        \fi                                                                                                                                                
+                                                    \ifnum\c@numauthors=15
+                                                        \chapter@authorone\vskip6\p@
+        {\it\fontsize{10\p@}{10\p@}\selectfont\chapter@affiliationone}\vskip12\p@
+                                                            \chapter@authortwo\vskip6\p@
+        {\it\fontsize{10\p@}{10\p@}\selectfont\chapter@affiliationtwo}\vskip12\p@
+                                                                \chapter@authorthree\vskip6\p@
+        {\it\fontsize{10\p@}{10\p@}\selectfont\chapter@affiliationthree}\vskip12\p@
+                                                                    \chapter@authorfour\vskip6\p@
+        {\it\fontsize{10\p@}{10\p@}\selectfont\chapter@affiliationfour}\vskip12\p@
+                                                                      \chapter@authorfive\vskip6\p@
+        {\it\fontsize{10\p@}{10\p@}\selectfont\chapter@affiliationfive}\vskip12\p@
+                                                                       \chapter@authorsix\vskip6\p@
+        {\it\fontsize{10\p@}{10\p@}\selectfont\chapter@affiliationsix}\vskip12\p@
+                                                                       \chapter@authorseven\vskip6\p@
+        {\it\fontsize{10\p@}{10\p@}\selectfont\chapter@affiliationseven}\vskip12\p@
+                                                                        \chapter@authoreight\vskip6\p@
+        {\it\fontsize{10\p@}{10\p@}\selectfont\chapter@affiliationeight}\vskip12\p@
+                                                                        \chapter@authornine\vskip6\p@
+        {\it\fontsize{10\p@}{10\p@}\selectfont\chapter@affiliationnine}\vskip12\p@        
+                                                                        \chapter@authorten\vskip6\p@
+        {\it\fontsize{10\p@}{10\p@}\selectfont\chapter@affiliationten}\vskip12\p@        
+                                                                        \chapter@authoreleven\vskip6\p@
+        {\it\fontsize{10\p@}{10\p@}\selectfont\chapter@affiliationeleven}\vskip12\p@        
+                                                                        \chapter@authortwelve\vskip6\p@
+        {\it\fontsize{10\p@}{10\p@}\selectfont\chapter@affiliationtwelve}\vskip12\p@        
+                                                                        \chapter@authorthirteen\vskip6\p@
+        {\it\fontsize{10\p@}{10\p@}\selectfont\chapter@affiliationthirteen}\vskip12\p@                                                                                                                                                                                              							\chapter@authorfourteen\vskip6\p@
+        {\it\fontsize{10\p@}{10\p@}\selectfont\chapter@affiliationfourteen}\vskip12\p@                                                                              
+							\chapter@authorfifteen\vskip6\p@
+        {\it\fontsize{10\p@}{10\p@}\selectfont\chapter@affiliationfifteen}                                                                                       
+         \fi                                                                                                                                                
+
+}
+ \gdef\chapter@authorone{}\gdef\chapter@affiliationone{}%
+ \gdef\chapter@authortwo{}\gdef\chapter@affiliationtwo{}%
+ \gdef\chapter@authorthree{}\gdef\chapter@affiliationthree{}%
+ \gdef\chapter@authorfour{}\gdef\chapter@affiliationfour{}%
+  \gdef\chapter@authorfive{}\gdef\chapter@affiliationfive{}%
+   \gdef\chapter@authorsix{}\gdef\chapter@affiliationsix{}%
+    \gdef\chapter@authorseven{}\gdef\chapter@affiliationseven{}%
+     \gdef\chapter@authoreight{}\gdef\chapter@affiliationeight{}%
+      \gdef\chapter@authornine{}\gdef\chapter@affiliationnine{}%
+       \gdef\chapter@authorten{}\gdef\chapter@affiliationten{}%
+   \gdef\chapter@authoreleven{}\gdef\chapter@affiliationeleven{}%
+    \gdef\chapter@authortwelve{}\gdef\chapter@affiliationtwelve{}%
+     \gdef\chapter@authorthirteen{}\gdef\chapter@affiliationthirteen{}%
+      \gdef\chapter@authorfourteen{}\gdef\chapter@affiliationfourteen{}%
+       \gdef\chapter@authorfifteen{}\gdef\chapter@affiliationfifteen{}%       
+       
+  \vskip 14.6\p@
+{\leftskip\secnumwidth\def\author##1##2{}\@input{\thechapter.toc}\par}%
+  }
+\reset@authors}
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+\newif\iffinishedfromone
+\global\finishedfromonefalse
 %
-%%\newenvironment{shortbox}{\par\addvspace{12pt plus2pt}%
-%%\if@krantza
-%%\setbox\tempbox\vbox\bgroup\hsize27pc%
-%%\else\if@krantzb
-%%\setbox\tempbox\vbox\bgroup\hsize32pc%
-%%\else
-%%\setbox\tempbox\vbox\bgroup\hsize25pc%
-%%\fi\fi
-%%}{%
-%%\egroup%
-%%\noindent\fboxsep6pt\fboxrule.5pt\hspace*{0pt}\fbox{\box\tempbox}
-%%\par\addvspace{12pt plus2pt}}%
+\newif\iffinishedfromtwo
+\global\finishedfromtwofalse
 %
+\newif\iffinishedfromthree
+\global\finishedfromthreefalse
+%
+\newif\iffinishedfromfour
+\global\finishedfromfourfalse
+%
+\newif\iffinishedfromfive
+\global\finishedfromfivefalse
+%
+\newif\iffinishedfromsix
+\global\finishedfromsixfalse
+%
+\newif\iffinishedfromseven
+\global\finishedfromsevenfalse
+%
+\newif\iffinishedfromeight
+\global\finishedfromeightfalse
+%
+\newif\iffinishedfromnine
+\global\finishedfromninefalse
+%
+\newif\iffinishedfromten
+\global\finishedfromtenfalse
+%
+\newif\iffinishedfromeleven
+\global\finishedfromelevenfalse
+%
+\newif\iffinishedfromtwelve
+\global\finishedfromtwelvefalse
+%
+\newif\iffinishedfromthirteen
+\global\finishedfromthirteenfalse
+%
+\newif\iffinishedfromfourteen
+\global\finishedfromfourteenfalse
+%
+\newif\iffinishedfromfifteen
+\global\finishedfromfifteenfalse
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%
+\def\singleauthorchapter{\finishedfromonetrue}
+\def\twoauthorchapter{\finishedfromtwotrue}
+\def\threeauthorchapter{\finishedfromthreetrue}
+\def\fourauthorchapter{\finishedfromfourtrue}
+\def\fiveauthorchapter{\finishedfromfivetrue}
+\def\sixauthorchapter{\finishedfromsixtrue}
+\def\sevenauthorchapter{\finishedfromseventrue}
+\def\eightauthorchapter{\finishedfromeighttrue}
+\def\nineauthorchapter{\finishedfromninetrue}
+\def\tenauthorchapter{\finishedfromtentrue}
+\def\elevenauthorchapter{\finishedfromeleventrue}
+\def\twelveauthorchapter{\finishedfromtwelvetrue}
+\def\thirteenauthorchapter{\finishedfromthirteentrue}
+\def\fourteenauthorchapter{\finishedfromfourteentrue}
+\def\fifteenauthorchapter{\finishedfromfifteentrue}
+%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+\newif\iffinish
+\global\finishfalse
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+\newsavebox\@AUonebox
+\newsavebox\@AUtwobox
+\newsavebox\@AUthreebox
+\newsavebox\@AUfourbox
+\newsavebox\@AUfivebox
+\newsavebox\@AUsixbox
+\newsavebox\@AUsevenbox
+\newsavebox\@AUeightbox
+\newsavebox\@AUninebox
+\newsavebox\@AUtenbox
+\newsavebox\@AUelevenbox
+\newsavebox\@AUtwelvebox
+\newsavebox\@AUthirteenbox
+\newsavebox\@AUfourteenbox
+\newsavebox\@AUfifteenbox
+
+%
+\newsavebox\@AUaffonebox
+\newsavebox\@AUafftwobox
+\newsavebox\@AUaffthreebox
+\newsavebox\@AUafffourbox
+\newsavebox\@AUafffivebox
+\newsavebox\@AUaffsixbox
+\newsavebox\@AUaffsevenbox
+\newsavebox\@AUaffeightbox
+\newsavebox\@AUaffninebox
+\newsavebox\@AUafftenbox
+\newsavebox\@AUaffelevenbox
+\newsavebox\@AUafftwelvebox
+\newsavebox\@AUaffthirteenbox
+\newsavebox\@AUafffourteenbox
+\newsavebox\@AUafffifteenbox
+
+%
+\newsavebox\@finalAUboxfromone
+\newsavebox\@finalAUboxfromtwo
+\newsavebox\@finalAUboxfromthree
+\newsavebox\@finalAUboxfromfour
+\newsavebox\@finalAUboxfromfive
+\newsavebox\@finalAUboxfromsix
+\newsavebox\@finalAUboxfromseven
+\newsavebox\@finalAUboxfromeight
+\newsavebox\@finalAUboxfromnine
+\newsavebox\@finalAUboxfromten
+\newsavebox\@finalAUboxfromeleven
+\newsavebox\@finalAUboxfromtwelve
+\newsavebox\@finalAUboxfromthirteen
+\newsavebox\@finalAUboxfromfourteen
+\newsavebox\@finalAUboxfromfifteen
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+\def\@ca#1#2{%
+%  \def\chapter@author{#1}%
+%  \def\chapter@affiliation{#2}%
+  \if@filesw%
+    \write\@auxout{%
+\string\@writefile{toc}{\string\author{#1}{}}%
+}%
+  \fi
+%%%%%%%%%%%%%%%
+
+\ifnum\c@numauthors>15
+    \resetcounter{numauthors}
+\fi 
+\stepcounter{numauthors}
+%%\the\c@numauthors
+\ifnum\c@numauthors=1 % 
+    \sbox\@AUonebox{\CAPlusOneFont#1}
+    \sbox\@AUaffonebox{\vbox{\hsize\textwidth\CAAPlusOneFont\noindent #2\par}}
+    \sbox\@finalAUboxfromone{\copy\@AUonebox}
+    \def\chapter@authorone{\copy\@finalAUboxfromone}
+    \def\chapter@affiliationone{\copy\@AUaffonebox}
+\fi \ifnum\c@numauthors=2
+    \sbox\@AUtwobox{\CAPlusOneFont#1}
+    \sbox\@AUafftwobox{\vbox{\hsize\textwidth\CAAPlusOneFont\noindent #2\par}}
+    \sbox\@finalAUboxfromtwo{\copy\@AUtwobox}
+    \def\chapter@authortwo{\copy\@finalAUboxfromtwo}
+    \def\chapter@affiliationtwo{\copy\@AUafftwobox}
+\fi \ifnum\c@numauthors=3
+    \sbox\@AUthreebox{\CAPlusOneFont#1}
+    \sbox\@AUaffthreebox{\vbox{\hsize\textwidth\CAAPlusOneFont\noindent #2\par}}
+    \sbox\@finalAUboxfromthree{\copy\@AUthreebox}
+    \def\chapter@authorthree{\copy\@finalAUboxfromthree}
+    \def\chapter@affiliationthree{\copy\@AUaffthreebox}
+\fi \ifnum\c@numauthors=4
+    \sbox\@AUfourbox{\CAPlusOneFont#1}
+    \sbox\@AUafffourbox{\vbox{\hsize\textwidth\CAAPlusOneFont\noindent #2\par}}
+    \sbox\@finalAUboxfromfour{\copy\@AUfourbox}
+    \def\chapter@authorfour{\copy\@finalAUboxfromfour}
+    \def\chapter@affiliationfour{\copy\@AUafffourbox}
+\fi \ifnum\c@numauthors=5
+    \sbox\@AUfivebox{\CAPlusOneFont#1}
+    \sbox\@AUafffivebox{\vbox{\hsize\textwidth\CAAPlusOneFont\noindent #2\par}}
+    \sbox\@finalAUboxfromfive{\copy\@AUfivebox}
+    \def\chapter@authorfive{\copy\@finalAUboxfromfive}
+    \def\chapter@affiliationfive{\copy\@AUafffivebox}
+\fi \ifnum\c@numauthors=6
+    \sbox\@AUsixbox{\CAPlusOneFont#1}
+    \sbox\@AUaffsixbox{\vbox{\hsize\textwidth\CAAPlusOneFont\noindent #2\par}}
+    \sbox\@finalAUboxfromsix{\copy\@AUsixbox}
+    \def\chapter@authorsix{\copy\@finalAUboxfromsix}
+    \def\chapter@affiliationsix{\copy\@AUaffsixbox}
+\fi \ifnum\c@numauthors=7
+    \sbox\@AUsevenbox{\CAPlusOneFont#1}
+    \sbox\@AUaffsevenbox{\vbox{\hsize\textwidth\CAAPlusOneFont\noindent #2\par}}
+    \sbox\@finalAUboxfromseven{\copy\@AUsevenbox}
+    \def\chapter@authorseven{\copy\@finalAUboxfromseven}
+    \def\chapter@affiliationseven{\copy\@AUaffsevenbox}
+\fi \ifnum\c@numauthors=8
+    \sbox\@AUeightbox{\CAPlusOneFont#1}
+    \sbox\@AUaffeightbox{\vbox{\hsize\textwidth\CAAPlusOneFont\noindent #2\par}}
+    \sbox\@finalAUboxfromeight{\copy\@AUeightbox}
+    \def\chapter@authoreight{\copy\@finalAUboxfromeight}
+    \def\chapter@affiliationeight{\copy\@AUaffeightbox}
+\fi \ifnum\c@numauthors=9
+    \sbox\@AUninebox{\CAPlusOneFont#1}
+    \sbox\@AUaffninebox{\vbox{\hsize\textwidth\CAAPlusOneFont\noindent #2\par}}
+    \sbox\@finalAUboxfromnine{\copy\@AUninebox}
+    \def\chapter@authornine{\copy\@finalAUboxfromnine}
+    \def\chapter@affiliationnine{\copy\@AUaffninebox}
+\fi \ifnum\c@numauthors=10
+    \sbox\@AUtenbox{\CAPlusOneFont#1}
+    \sbox\@AUafftenbox{\vbox{\hsize\textwidth\CAAPlusOneFont\noindent #2\par}}
+    \sbox\@finalAUboxfromten{\copy\@AUtenbox}
+    \def\chapter@authorten{\copy\@finalAUboxfromten}
+    \def\chapter@affiliationten{\copy\@AUafftenbox}
+\fi \ifnum\c@numauthors=11
+    \sbox\@AUelevenbox{\CAPlusOneFont#1}
+    \sbox\@AUaffelevenbox{\vbox{\hsize\textwidth\CAAPlusOneFont\noindent #2\par}}
+    \sbox\@finalAUboxfromeleven{\copy\@AUelevenbox}
+    \def\chapter@authoreleven{\copy\@finalAUboxfromeleven}
+    \def\chapter@affiliationeleven{\copy\@AUaffelevenbox}
+\fi \ifnum\c@numauthors=12
+    \sbox\@AUtwelvebox{\CAPlusOneFont#1}
+    \sbox\@AUafftwelvebox{\vbox{\hsize\textwidth\CAAPlusOneFont\noindent #2\par}}
+    \sbox\@finalAUboxfromtwelve{\copy\@AUtwelvebox}
+    \def\chapter@authortwelve{\copy\@finalAUboxfromtwelve}
+    \def\chapter@affiliationtwelve{\copy\@AUafftwelvebox}
+\fi \ifnum\c@numauthors=13
+    \sbox\@AUthirteenbox{\CAPlusOneFont#1}
+    \sbox\@AUaffthirteenbox{\vbox{\hsize\textwidth\CAAPlusOneFont\noindent #2\par}}
+    \sbox\@finalAUboxfromthirteen{\copy\@AUthirteenbox}
+    \def\chapter@authorthirteen{\copy\@finalAUboxfromthirteen}
+    \def\chapter@affiliationthirteen{\copy\@AUaffthirteenbox}
+\fi\ifnum\c@numauthors=14
+    \sbox\@AUfourteenbox{\CAPlusOneFont#1}
+    \sbox\@AUafffourteenbox{\vbox{\hsize\textwidth\CAAPlusOneFont\noindent #2\par}}
+    \sbox\@finalAUboxfromfourteen{\copy\@AUfourteenbox}
+    \def\chapter@authorfourteen{\copy\@finalAUboxfromfourteen}
+    \def\chapter@affiliationfourteen{\copy\@AUafffourteenbox}
+\fi\ifnum\c@numauthors=15
+    \sbox\@AUfifteenbox{\CAPlusOneFont#1}
+    \sbox\@AUafffifteenbox{\vbox{\hsize\textwidth\CAAPlusOneFont\noindent #2\par}}
+    \sbox\@finalAUboxfromfifteen{\copy\@AUfifteenbox}
+    \def\chapter@authorfifteen{\copy\@finalAUboxfromfifteen}
+    \def\chapter@affiliationfifteen{\copy\@AUafffifteenbox}
+\fi}
 
 
+
+\def\@caplusone{\@ifstar{\@scaplusone}{\@ifnextchar[{\@xcaplusone}{\@xcaplusone[]}}}
+\def\@xcaplusone[#1]#2#3{%
+  \def\@@empty{#1}\ifx\@empty\@@empty\@ca{#2}{#3}\else\@ca{#2}{#1}\fi\@scaplusone{#2}{#3}}
+\def\@scaplusone#1#2{%
+  \ifhmode\vskip-12pt\fi
+%%Shashi Commented
+%%%  \noindent\hskip3pc{\CAPlusOneFont\baselineskip14pt #1\def\@t{#2}\ifx\@t\@empty\else,\fi}\hskip6pt{\CAAPlusOneFont #2}\par
+}
+
+\def\chapterauthoronly#1#2{\@ca{#1}{}\@scaplusone{#1}{#2}}
+\def\myaddcontentsline#1#2#3{%
+  \if@filesw
+    \begingroup
+    \let\label\@gobble\let\index\@gobble\let\glossary\@gobble
+    \def\break{\ }%
+    \def\protect##1{\string ##1 }%
+    \@temptokena{\thepage}%
+    \edef\@tempa{\write#1{\string\chapcontentsline{#2}{\string\raggedright\space #3}{\the\@temptokena}}}\@tempa
+%    \if@nobreak\ifvmode\nobreak\fi\fi%%%nobreak error
+    \endgroup
+  \fi}
+\def\chapcontentsline#1{\csname l@#1\endcsname}
+\def\l@chapsection{\@mydottedtocline{1}{\z@}{6pt}}
+\def\l@chapsubsection{\@mydottedtocline{2}{\secnumwidth}{6pt}}
+\def\l@chapsubsubsection{\@mydottedtocline{3}{\subsecnumwidth}{36pt}}
+\newcount\c@chaptocdepth
+\setcounter{chaptocdepth}{3}
+\def\@mytocline#1#2#3#4#5{%
+  \ifnum #1>\c@chaptocdepth
+  \else
+    \vskip 2pt plus.2\p@
+    \ifnum #1=1\ifnum\c@chaptocdepth>1\addvspace{12pt}\fi\fi
+    {\leftskip #2\relax% \rightskip \@tocrmarg \parfillskip -\rightskip
+      \interlinepenalty\@M
+      \leavevmode
+      \@tempdima #3\relax
+      \rightskip\z@
+      \vbox{\ChapTOCFont #4\nobreak}%
+      \par}\fi}
+\def\@mydottedtocline#1#2#3#4#5{%
+  \ifnum #1>\c@chaptocdepth
+  \else
+\fontsize{10}{12}\selectfont
+{\leftskip #2\relax \rightskip \@tocrmarg \parfillskip -\rightskip
+     % \parindent #2\relax\@afterindenttrue
+      \interlinepenalty\@M
+      \leavevmode
+      \def\@dotsep{1.2}%
+      \@tempdima #3\relax
+      \rightskip\z@
+%      \advance\hsize-\secnumwidth
+%      \hskip-\secnumwidth
+\if@krantzb
+\hangindent\secnumwidth\hsize372pt\else\hangindent\secnumwidth\hsize312pt\fi 
+#4
+        \if@pdf
+          \hfill
+        \else
+          \nobreak\leaders\hbox{$\m@th\mkern\@dotsep mu.\mkern\@dotsep mu$}\hfill\nobreak
+          \hbox to24\p@{\hfil #5}\fi
+      \par}\fi}      
+
+      
+\newcommand\listoffigures{%
+    \if@twocolumn
+      \@restonecoltrue\onecolumn
+    \else
+      \@restonecolfalse
+    \fi
+    \chapter*{\listfigurename}%
+      \@mkboth{\MakeUppercase\listfigurename}%
+              {\MakeUppercase\listfigurename}%
+    \@starttoc{lof}%
+    \if@restonecol\twocolumn\fi
+    }
+\newcommand*\l@figure{\@dottedtocline{1}{1.5em}{2.3em}}
+\newcommand\listoftables{%
+    \if@twocolumn
+      \@restonecoltrue\onecolumn
+    \else
+      \@restonecolfalse
+    \fi
+    \chapter*{\listtablename}%
+      \@mkboth{%
+          \MakeUppercase\listtablename}%
+         {\MakeUppercase\listtablename}%
+    \@starttoc{lot}%
+    \if@restonecol\twocolumn\fi
+    }
+\let\l@table\l@figure
+\newdimen\bibindent
+\setlength\bibindent{1.5em}
+\newenvironment{thebibliography}[1]
+     {\chapter*{\bibname}%\MakeUppercase
+      \@mkboth{\bibname}{\bibname}%\MakeUppercase
+      \list{\@biblabel{\@arabic\c@enumiv}}%
+           {\settowidth\labelwidth{\@biblabel{#1}}%
+            \leftmargin\labelwidth
+            \advance\leftmargin\labelsep
+            \@openbib@code
+            \usecounter{enumiv}%
+            \let\p@enumiv\@empty
+            \renewcommand\theenumiv{\@arabic\c@enumiv}}%
+      \sloppy
+      \clubpenalty4000
+      \@clubpenalty \clubpenalty
+      \widowpenalty4000%
+      \sfcode`\.\@m}
+     {\def\@noitemerr
+       {\@latex@warning{Empty `thebibliography' environment}}%
+      \endlist}
+\newcommand\newblock{\hskip .11em\@plus.33em\@minus.07em}
+\let\@openbib@code\@empty
+\newenvironment{theindex}
+               {\if@twocolumn
+                  \@restonecolfalse
+                \else
+                  \@restonecoltrue
+                \fi
+                \twocolumn[\@makeschapterhead{\indexname}]%
+                \@mkboth{\indexname}%\MakeUppercase
+                        {\indexname}%\MakeUppercase
+                \thispagestyle{folio}\parindent\z@\pagestyle{headings}
+                        \addcontentsline{toc}{chapter}{\indexname}
+                \parskip\z@ \@plus .3\p@\relax\raggedright
+                \columnseprule \z@
+                \columnsep 35\p@
+                \let\item\@idxitem}
+               {\if@restonecol\onecolumn\else\clearpage\fi}
+\newcommand\@idxitem{\par\hangindent 40\p@}
+\newcommand\subitem{\@idxitem \hspace*{20\p@}}
+\newcommand\subsubitem{\@idxitem \hspace*{30\p@}}
+\newcommand\indexspace{\par \vskip 10\p@ \@plus5\p@ \@minus3\p@\relax}
+\renewcommand\footnoterule{%
+  \kern-3\p@
+  \hrule\@width.4\columnwidth
+  \kern2.6\p@}
+\@addtoreset{footnote}{chapter}
+\newcommand\@makefntext[1]{%
+    \parindent 1em%
+    \noindent
+    \hb@xt@1.8em{\hss\@makefnmark}#1}
+    
 \def\grayink{\special{color cmyk 0 0 0 0.2}}
 \def\blackink{\special{color cmyk 0 0 0 1.0}} %  
 \def\whiteink{\special{color cmyk 0 0 0 0}} % 0%
@@ -1795,17 +2085,17 @@
 }{\end{shaded*}}
 
 \newenvironment{shortbox}{
-\begin{framed}}{\end{framed}}
+\begin{oframed}}{\end{oframed}}
 
 
-%%\newenvironment{shadebox}{%
-%%\setbox\tempbox\hbox\bgroup\vbox\bgroup\leftskip12pt\rightskip\leftskip}{\par\addvspace{12pt}
-%%\egroup\egroup\par\addvspace{25pt} 
-%%\tempdimen\ht\tempbox
-%%\advance\tempdimen by 1pc
-%%\noindent{\hbox to \wd\tempbox{\vbox to \ht\tempbox{\hsize\textwidth{\special{color push}\grayink\vspace*{-12pt}\noindent\vrule height\tempdimen width\textwidth 
-%%\special{color pop}\blackink}}}}%
-%%\llap{\unhbox\tempbox}\par\addvspace{12pt}}
+\def\tch#1{\TableColHeadFont #1\llstrut\hfill}
+\def\tsh#1{\TableSubheadFont #1\hfill}
+\newcommand\llstrut{\rule[-6pt]{0pt}{14pt}}
+\newcommand\flstrut{\rule{0pt}{10pt}}
+\newcommand\tabletitlestrut{\rule{0pt}{20pt}}
+
+\def\Boxhead#1{\par\addvspace{3pt plus2pt}\noindent{\centering\bfseries#1\par}\vskip3pt}
+
 
 %%%%%%%%%% Note %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \newbox\tempbox
@@ -2044,8 +2334,8 @@
                 \columnsep 35\p@
                 \let\contau\@conitem}
                {\if@restonecol\onecolumn\else\clearpage\fi}
-\newcommand\@conitem{\par\addvspace{10pt}\bf\hangindent 40\p@}
-\newcommand\contaff{\par\normalfont\hangindent 12\p@}
+\newcommand\@conitem{\par\addvspace{10pt}\ContributorNameFont\hangindent 40\p@}
+\newcommand\contaff{\par\ContributorAffiliationFont\hangindent 12\p@}
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -2054,14 +2344,52 @@
     
 \frenchspacing
 \tolerance=5000    
-\raggedbottom
-
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+\raggedbottom    
+    
+    
+    
+\newcommand\contentsname{Contents}
+\newcommand\listfigurename{List of Figures}
+\newcommand\listtablename{List of Tables}
+\newcommand\bibname{Bibliography}
+\newcommand\indexname{Index}
+\newcommand\figurename{FIGURE}
+\newcommand\tablename{TABLE}
+\newcommand\partname{Part}
+\newcommand\chaptername{Chapter}
+\newcommand\appendixname{Appendix}
+\def\today{\ifcase\month\or
+  January\or February\or March\or April\or May\or June\or
+  July\or August\or September\or October\or November\or December\fi
+  \space\number\day, \number\year}
+\setlength\columnsep{10\p@}
+\setlength\columnseprule{0\p@}
+\pagestyle{headings}
+\pagenumbering{arabic}
+\if@twoside
+\else
+  \raggedbottom
+\fi
+\if@twocolumn
+  \twocolumn
+  \sloppy
+  \flushbottom
+\else
+  \onecolumn
+\fi
+\newcommand\unnumcrcrule{\hbox to\textwidth{\rlap{\rule[-3.5\p@]{84\p@}{4\p@}}}}
+\newcommand\unnumchap@rule{\unnumcrcrule}
+\newcommand\crcrule{\hbox to\textwidth{\rlap{\rule[-3.5\p@]{84\p@}{4\p@}}\rule{\textwidth}{.5\p@}}}
+\newcommand\chap@rule{\crcrule}
+\newcommand\sec@rule{\crcrule}
+\def\@affiliate[#1]{\gdef\@affiliation{#1}}
+\def\@affiliation{}
 
 \@centertabletitlefalse
 %\HeadingsBookChapter
 \HeadingsChapterSection
+
+
 \endinput
 %%
 %% End of file `krantz.cls'.
-         


### PR DESCRIPTION
This PR:
* has the foreword as frontmatter
* adds the table of contents
* makes various changes to make the numbering be correct in the table of contents
* uses a newer version of the Krantz class file that the Tidy Finance for Python folks were using