### PR TITLE
Fix table formatting and long output

### DIFF
--- a/data_manipulation.qmd
+++ b/data_manipulation.qmd
@@ -280,6 +280,7 @@ We could express this more concisely using `mutate()`, like this:
 
 ```{r}
 #| label: de-meaned-commute
+#| eval: false
 pums_person |>
   group_by(location, year) |>
   mutate(

--- a/datasets.qmd
+++ b/datasets.qmd
@@ -115,17 +115,19 @@ The previous examples used Arrow and Parquet datasets, but Arrow supports the sa
 
 The different functions for reading and writing datasets are shown in @tbl-dataset-funcs below.
 
-+-----------------------------+--------------------------------------------------------+------------------------------------+
-| Format                      | Reading                                                | Writing                            |
-+:===========================+:======================================================+:==================================+
-| Parquet                     | open_dataset()                                         | write_dataset()                    |
-+-----------------------------+--------------------------------------------------------+------------------------------------+
-| CSV or other delimited file | open_dataset(..., format = "csv"), open_csv_dataset(), | write_dataset(..., format = "csv") |
-|                             |                                                        |                                    |
-|                             | open_delim_dataset()                                   |                                    |
-+-----------------------------+--------------------------------------------------------+------------------------------------+
-| Line-delimited JSON         | open_dataset(..., format = "json")                     | (Not supported)                    |
-+-----------------------------+--------------------------------------------------------+------------------------------------+
++---------------------------+------------------------------------+------------------------------------+
+| Format                    | Reading                            | Writing                            |
++:==========================+:===================================+:===================================+
+| Parquet                   | open_dataset()                     | write_dataset()                    |
++---------------------------+------------------------------------+------------------------------------+
+| CSV                       | open_dataset(..., format = "csv"), | write_dataset(..., format = "csv") |
+|                           |                                    |                                    |
+| (or other delimited file) | open_csv_dataset(),                |                                    |
+|                           |                                    |                                    |
+|                           | open_delim_dataset()               |                                    |
++---------------------------+------------------------------------+------------------------------------+
+| Line-delimited JSON       | open_dataset(..., format = "json") | (Not supported)                    |
++---------------------------+------------------------------------+------------------------------------+
 
 : Functions for reading and writing datasets {#tbl-dataset-funcs}
 


### PR DESCRIPTION
PR to fix a couple of tiny things which were not looking right in the PDF:

* reformatting a table
* not printing out a query with a large schema