### PR TITLE
A bit of publishing cleanup

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+arrowrbook.com

--- a/_quarto-pdf.yml
+++ b/_quarto-pdf.yml
@@ -1,0 +1,26 @@
+format:
+  pdf:
+    template-partials: 
+      - latex/title.tex
+    highlight-style: monochrome
+    toc: false
+    toc-title: "Contents"
+    keep-tex: true
+    cite-method: natbib
+    biblio-style: apalike
+    documentclass: krantz
+    classoption: [krantz2]
+    fig-width: 6
+    # fig-height: 9
+    format-resources:
+      - latex/krantz.cls
+    hyperrefoptions: "bookmarks=false"
+    links-as-notes: true
+    colorlinks: false
+    # For breaking lines in output
+    knitr:
+      opts_chunk:
+        R.options:
+          width: 64
+    include-in-header: latex/in_header.tex
+    include-before-body: latex/before_body.tex

--- a/_quarto-website.yml
+++ b/_quarto-website.yml
@@ -8,6 +8,10 @@ format:
     author: "Nic Crane, Jonathan Keane, and Neal Richardson"
     reader-mode: true
     google-analytics: "G-4JT42QR6DV"
+    site-url: https://arrowrbook.com/
+    repo-url: https://github.com/arrowrbook/book/
+    repo-branch: main
+    repo-actions: [source, issue]
     page-footer:
       left: |
         Scaling Up With R and Arrow was written by Nic Crane, Jonathan Keane,

--- a/_quarto-website.yml
+++ b/_quarto-website.yml
@@ -1,0 +1,16 @@
+format:
+  html:
+    theme: cosmo
+    df-print: paged
+    fig-width: 8
+    fig-height: 6
+    subtitle: "Bigger Data, Easier Workflows"
+    author: "Nic Crane, Jonathan Keane, and Neal Richardson"
+    reader-mode: true
+    google-analytics: "G-4JT42QR6DV"
+    page-footer:
+      left: |
+        Scaling Up With R and Arrow was written by Nic Crane, Jonathan Keane,
+        and Neal Richardson.
+      right: |
+        This book was built with <a href="https://quarto.org/">Quarto</a>.

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -25,51 +25,9 @@ book:
 
 bibliography: references.bib
 
-format:
-  html:
-    theme: cosmo
-    df-print: paged
-    fig-width: 8
-    fig-height: 6
-    subtitle: "Bigger Data, Easier Workflows"
-    author: "Nic Crane, Jonathan Keane, and Neal Richardson"
-    reader-mode: true
-    google-analytics: "G-4JT42QR6DV"
-    page-footer:
-      left: |
-        Scaling Up With R and Arrow was written by Nic Crane, Jonathan Keane,
-        and Neal Richardson.
-      right: |
-        This book was built with <a href="https://quarto.org/">Quarto</a>.
-  pdf:
-    template-partials: 
-      - latex/title.tex
-    highlight-style: monochrome
-    toc: false
-    toc-title: "Contents"
-    keep-tex: true
-    cite-method: natbib
-    biblio-style: apalike
-    documentclass: krantz
-    classoption: [krantz2]
-    fig-width: 6
-    # fig-height: 9
-    format-resources:
-      - latex/krantz.cls
-    hyperrefoptions: "bookmarks=false"
-    links-as-notes: true
-    colorlinks: false
-    # For breaking lines in output
-    knitr:
-      opts_chunk:
-        R.options:
-          width: 64
-    include-in-header: latex/in_header.tex
-    include-before-body: latex/before_body.tex
-        
-    # highlight-style: grayscale-custom.theme
-    # include-before-body: latex/before_body.tex
-    # include-after-body: latex/after_body.tex
+profile:
+  group: 
+    - [website, pdf]
 
 editor: source
 

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -1,6 +1,8 @@
 project:
   type: book
   output-dir: _book
+  resources: 
+    - CNAME
 
 book:
   # we may need to comment the title out when rendering final version to pdf

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -22,6 +22,10 @@ book:
     - references.qmd
   appendices:
   - appendix.qmd
+  site-url: https://arrowrbook.com/
+  repo-url: https://github.com/arrowrbook/book/
+  repo-branch: main
+  repo-actions: [source, issue]
 
 bibliography: references.bib
 

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -22,10 +22,6 @@ book:
     - references.qmd
   appendices:
   - appendix.qmd
-  site-url: https://arrowrbook.com/
-  repo-url: https://github.com/arrowrbook/book/
-  repo-branch: main
-  repo-actions: [source, issue]
 
 bibliography: references.bib
 

--- a/writers notes/README.md
+++ b/writers notes/README.md
@@ -14,9 +14,9 @@ Doing this allows us to have quick iteration cycles knowing that we can compile 
 To render and publish with the full dataset (all of this is done locally):
 
 * remove the `_freeze/` directory
-* run `quarto publish gh-pages`
+* run `quarto publish`
 
-This will automatically render the book and then add the files to the `gh-pages` branch where the book is hosted from.
+This will automatically render the book and then add the files to the `gh-pages` branch where the book is hosted from. We use porfiles to prevent quarto from also rendering and sending the PDF. The website profile is the default.
 
 #### PR previews
 

--- a/writers notes/README.md
+++ b/writers notes/README.md
@@ -13,10 +13,10 @@ Doing this allows us to have quick iteration cycles knowing that we can compile 
 
 To render and publish with the full dataset (all of this is done locally):
 
-* remove the `_freeze/` directory
-* run `quarto publish`
+* remove the `_freeze/` and `_book/` directories
+* run `quarto publish gh-pages`
 
-This will automatically render the book and then add the files to the `gh-pages` branch where the book is hosted from. We use porfiles to prevent quarto from also rendering and sending the PDF. The website profile is the default.
+This will automatically render the book and then add the files to the `gh-pages` branch where the book is hosted from. We use profiles to prevent quarto from also rendering and sending the PDF. The website profile is the default. The first point is not strictly necessary, but any freezes you might have (say from rendering with subset data) will be used if they exist and any files that are in `_book` will be published. 
 
 #### PR previews
 


### PR DESCRIPTION
The main impetus for this was to get the CNAME maintained across publishing actions. 

I also separated out the pdf from the website into different profiles — this looks like a lot, but this was the simplest way to make it so that `quarto publish gh-pages` did what we wanted (no PDF). I tried just passing `--to html` to the publish command, but that doesn't work so needed to do a bit more.

I also added some URLs into the quarto yaml while I was there so we get nice links (that hasn't been published yet, but it is similar to how the [ggplot book](https://ggplot2-book.org) looks if you're looking for what that will look like. 